### PR TITLE
feat: add Gate integration and comprehensive test suite

### DIFF
--- a/app/Commands/Concerns/ChecksAuthorization.php
+++ b/app/Commands/Concerns/ChecksAuthorization.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Commands\Concerns;
+
+use Illuminate\Support\Facades\Gate;
+
+trait ChecksAuthorization
+{
+    /**
+     * Check if the current user is authorized for the given ability.
+     */
+    protected function authorize(string $ability): bool
+    {
+        return Gate::allows($ability);
+    }
+
+    /**
+     * Check authorization and output error if not authorized.
+     *
+     * @return bool True if authorized, false if not
+     */
+    protected function authorizeOrFail(string $ability, ?string $customMessage = null): bool
+    {
+        if (! $this->authorize($ability)) {
+            $message = $customMessage ?? $this->getAuthorizationErrorMessage($ability);
+
+            if (method_exists($this, 'option') && $this->option('json')) {
+                $this->line(json_encode([
+                    'error' => true,
+                    'message' => $message,
+                    'required_scope' => $this->getRequiredScopeForAbility($ability),
+                ]));
+            } else {
+                $this->error("❌ {$message}");
+                $this->info('💡 Re-run "spotify login" to grant the required scopes');
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get a user-friendly error message for authorization failure.
+     */
+    protected function getAuthorizationErrorMessage(string $ability): string
+    {
+        $scope = $this->getRequiredScopeForAbility($ability);
+
+        return "Missing required scope: {$scope}";
+    }
+
+    /**
+     * Get the required Spotify scope for a given ability.
+     */
+    protected function getRequiredScopeForAbility(string $ability): string
+    {
+        $scopeMap = [
+            'spotify:play' => 'user-modify-playback-state',
+            'spotify:pause' => 'user-modify-playback-state',
+            'spotify:resume' => 'user-modify-playback-state',
+            'spotify:skip' => 'user-modify-playback-state',
+            'spotify:volume' => 'user-modify-playback-state',
+            'spotify:shuffle' => 'user-read-playback-state, user-modify-playback-state',
+            'spotify:repeat' => 'user-read-playback-state, user-modify-playback-state',
+            'spotify:queue' => 'user-modify-playback-state',
+            'spotify:current' => 'user-read-playback-state, user-read-currently-playing',
+            'spotify:devices' => 'user-read-playback-state',
+            'spotify:player' => 'user-read-playback-state, user-modify-playback-state',
+            'modify-playback' => 'user-modify-playback-state',
+            'read-playback' => 'user-read-playback-state',
+            'read-currently-playing' => 'user-read-currently-playing',
+        ];
+
+        return $scopeMap[$ability] ?? 'unknown';
+    }
+}

--- a/app/Commands/CurrentCommand.php
+++ b/app/Commands/CurrentCommand.php
@@ -2,11 +2,14 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
 class CurrentCommand extends Command
 {
+    use ChecksAuthorization;
+
     protected $signature = 'current {--json : Output as JSON}';
 
     protected $description = 'Show current track';
@@ -19,6 +22,10 @@ class CurrentCommand extends Command
             $this->error('❌ Spotify is not configured');
             $this->info('💡 Run "spotify setup" first');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:current')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/DevicesCommand.php
+++ b/app/Commands/DevicesCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
@@ -12,6 +13,7 @@ use function Laravel\Prompts\warning;
 
 class DevicesCommand extends Command
 {
+    use ChecksAuthorization;
     protected $signature = 'devices {--switch : Switch to a different device}';
 
     protected $description = 'List or switch Spotify devices';
@@ -24,6 +26,10 @@ class DevicesCommand extends Command
             error('❌ Spotify not configured');
             info('💡 Run "spotify setup" first');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:devices')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/LoginCommand.php
+++ b/app/Commands/LoginCommand.php
@@ -276,6 +276,7 @@ echo "Waiting for Spotify callback...";
                 'refresh_token' => $data['refresh_token'] ?? null,
                 'expires_in' => $data['expires_in'] ?? 3600,
                 'expires_at' => time() + ($data['expires_in'] ?? 3600),
+                'scope' => $data['scope'] ?? '',
             ];
         }
 

--- a/app/Commands/PauseCommand.php
+++ b/app/Commands/PauseCommand.php
@@ -2,11 +2,13 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
 class PauseCommand extends Command
 {
+    use ChecksAuthorization;
     /**
      * The name and signature of the console command.
      *
@@ -33,6 +35,10 @@ class PauseCommand extends Command
             $this->info('💡 Set SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET env vars');
             $this->info('💡 Then run "music login" to authenticate');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:pause')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/PlayCommand.php
+++ b/app/Commands/PlayCommand.php
@@ -2,11 +2,13 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
 class PlayCommand extends Command
 {
+    use ChecksAuthorization;
     protected $signature = 'play 
                             {query : Song, artist, or playlist to play} 
                             {--device= : Device name or ID to play on} 
@@ -24,6 +26,10 @@ class PlayCommand extends Command
             $this->info('💡 Run "spotify setup" to configure Spotify');
             $this->info('💡 Or set SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET env vars');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:play')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/PlayerCommand.php
+++ b/app/Commands/PlayerCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
@@ -11,6 +12,7 @@ use function Laravel\Prompts\spin;
 
 class PlayerCommand extends Command
 {
+    use ChecksAuthorization;
     protected $signature = 'player';
 
     protected $description = '🎵 Interactive Spotify player with visual controls';
@@ -27,6 +29,10 @@ class PlayerCommand extends Command
             $this->error('❌ Spotify is not configured');
             $this->info('💡 Run "spotify setup" first');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:player')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/QueueCommand.php
+++ b/app/Commands/QueueCommand.php
@@ -2,11 +2,13 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
 class QueueCommand extends Command
 {
+    use ChecksAuthorization;
     protected $signature = 'queue {query : Song, artist, or playlist to add to queue}';
 
     protected $description = 'Add a song to the Spotify queue (plays after current track)';
@@ -20,6 +22,10 @@ class QueueCommand extends Command
             $this->info('💡 Run "spotify setup" to configure Spotify');
             $this->info('💡 Or set SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET env vars');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:queue')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/RepeatCommand.php
+++ b/app/Commands/RepeatCommand.php
@@ -2,11 +2,13 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
 class RepeatCommand extends Command
 {
+    use ChecksAuthorization;
     protected $signature = 'repeat 
                             {state? : off/track/context/toggle - defaults to toggle}
                             {--json : Output as JSON}';
@@ -21,6 +23,10 @@ class RepeatCommand extends Command
             $this->error('❌ Spotify is not configured');
             $this->info('💡 Run "spotify setup" first');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:repeat')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/ResumeCommand.php
+++ b/app/Commands/ResumeCommand.php
@@ -2,11 +2,13 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
 class ResumeCommand extends Command
 {
+    use ChecksAuthorization;
     protected $signature = 'resume 
                             {--device= : Device name or ID to resume on}
                             {--json : Output as JSON}';
@@ -22,6 +24,10 @@ class ResumeCommand extends Command
             $this->info('💡 Run "spotify setup" to configure Spotify');
             $this->info('💡 Or set SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET env vars');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:resume')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/ShuffleCommand.php
+++ b/app/Commands/ShuffleCommand.php
@@ -2,12 +2,15 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
 class ShuffleCommand extends Command
 {
-    protected $signature = 'shuffle 
+    use ChecksAuthorization;
+
+    protected $signature = 'shuffle
                             {state? : on/off/toggle - defaults to toggle}
                             {--json : Output as JSON}';
 
@@ -21,6 +24,10 @@ class ShuffleCommand extends Command
             $this->error('❌ Spotify is not configured');
             $this->info('💡 Run "spotify setup" first');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:shuffle')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/SkipCommand.php
+++ b/app/Commands/SkipCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
@@ -10,6 +11,7 @@ use function Laravel\Prompts\info;
 
 class SkipCommand extends Command
 {
+    use ChecksAuthorization;
     protected $signature = 'skip 
                             {direction? : next or prev (default: next)}
                             {--json : Output as JSON}';
@@ -22,6 +24,10 @@ class SkipCommand extends Command
             error('❌ Spotify not configured');
             info('💡 Run "spotify setup" to get started');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:skip')) {
             return self::FAILURE;
         }
 

--- a/app/Commands/VolumeCommand.php
+++ b/app/Commands/VolumeCommand.php
@@ -2,11 +2,13 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\ChecksAuthorization;
 use App\Services\SpotifyService;
 use LaravelZero\Framework\Commands\Command;
 
 class VolumeCommand extends Command
 {
+    use ChecksAuthorization;
     protected $signature = 'volume 
                             {level? : Volume level (0-100) or +/- for relative change}
                             {--json : Output as JSON}';
@@ -21,6 +23,10 @@ class VolumeCommand extends Command
             $this->error('❌ Spotify is not configured');
             $this->info('💡 Run "spotify setup" first');
 
+            return self::FAILURE;
+        }
+
+        if (! $this->authorizeOrFail('spotify:volume')) {
             return self::FAILURE;
         }
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\SpotifyService;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * Scope-to-ability mappings for Spotify OAuth scopes.
+     */
+    protected array $scopeAbilities = [
+        // Playback read abilities
+        'read-playback' => 'user-read-playback-state',
+        'read-currently-playing' => 'user-read-currently-playing',
+
+        // Playback modify abilities
+        'modify-playback' => 'user-modify-playback-state',
+
+        // Playlist abilities
+        'read-playlists' => ['playlist-read-private', 'playlist-read-collaborative'],
+
+        // Streaming ability
+        'streaming' => 'streaming',
+    ];
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        $this->registerGates();
+    }
+
+    /**
+     * Register the Gate definitions for Spotify OAuth scopes.
+     */
+    protected function registerGates(): void
+    {
+        // Register individual scope abilities
+        foreach ($this->scopeAbilities as $ability => $scopes) {
+            Gate::define($ability, function ($user = null) use ($scopes) {
+                return $this->hasScope($scopes);
+            });
+        }
+
+        // Register composite abilities for commands
+        Gate::define('spotify:play', function ($user = null) {
+            return $this->hasScope('user-modify-playback-state');
+        });
+
+        Gate::define('spotify:pause', function ($user = null) {
+            return $this->hasScope('user-modify-playback-state');
+        });
+
+        Gate::define('spotify:resume', function ($user = null) {
+            return $this->hasScope('user-modify-playback-state');
+        });
+
+        Gate::define('spotify:skip', function ($user = null) {
+            return $this->hasScope('user-modify-playback-state');
+        });
+
+        Gate::define('spotify:volume', function ($user = null) {
+            return $this->hasScope('user-modify-playback-state');
+        });
+
+        Gate::define('spotify:shuffle', function ($user = null) {
+            return $this->hasScope(['user-read-playback-state', 'user-modify-playback-state']);
+        });
+
+        Gate::define('spotify:repeat', function ($user = null) {
+            return $this->hasScope(['user-read-playback-state', 'user-modify-playback-state']);
+        });
+
+        Gate::define('spotify:queue', function ($user = null) {
+            return $this->hasScope('user-modify-playback-state');
+        });
+
+        Gate::define('spotify:current', function ($user = null) {
+            return $this->hasScope(['user-read-playback-state', 'user-read-currently-playing']);
+        });
+
+        Gate::define('spotify:devices', function ($user = null) {
+            return $this->hasScope('user-read-playback-state');
+        });
+
+        Gate::define('spotify:player', function ($user = null) {
+            return $this->hasScope(['user-read-playback-state', 'user-modify-playback-state']);
+        });
+    }
+
+    /**
+     * Check if the current token has the required scope(s).
+     */
+    protected function hasScope(string|array $requiredScopes): bool
+    {
+        $spotify = app(SpotifyService::class);
+        $grantedScopes = $spotify->getGrantedScopes();
+
+        if (empty($grantedScopes)) {
+            return false;
+        }
+
+        $requiredScopes = (array) $requiredScopes;
+
+        foreach ($requiredScopes as $scope) {
+            if (! in_array($scope, $grantedScopes, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        //
+    }
+}

--- a/app/Services/SpotifyService.php
+++ b/app/Services/SpotifyService.php
@@ -12,6 +12,8 @@ class SpotifyService
 
     private ?int $expiresAt = null;
 
+    private array $grantedScopes = [];
+
     private string $clientId;
 
     private string $clientSecret;
@@ -51,6 +53,7 @@ class SpotifyService
                 $this->accessToken = $data['access_token'] ?? null;
                 $this->refreshToken = $data['refresh_token'] ?? null;
                 $this->expiresAt = $data['expires_at'] ?? null;
+                $this->parseScopes($data['scope'] ?? '');
 
                 return;
             }
@@ -76,6 +79,7 @@ class SpotifyService
                     $this->accessToken = $data['access_token'] ?? null;
                     $this->refreshToken = $data['refresh_token'] ?? null;
                     $this->expiresAt = $data['expires_at'] ?? null;
+                    $this->parseScopes($data['scope'] ?? '');
                 }
 
                 // Migrate to new location
@@ -87,6 +91,46 @@ class SpotifyService
                 return;
             }
         }
+            }
+        }
+    }
+
+    /**
+     * Parse scope string into array of scopes
+     */
+    private function parseScopes(string $scopeString): void
+    {
+        if (empty($scopeString)) {
+            $this->grantedScopes = [];
+
+            return;
+        }
+
+        $this->grantedScopes = array_filter(array_map('trim', explode(' ', $scopeString)));
+    }
+
+    /**
+     * Get the granted OAuth scopes
+     */
+    public function getGrantedScopes(): array
+    {
+        return $this->grantedScopes;
+    }
+
+    /**
+     * Check if a specific scope is granted
+     */
+    public function hasScope(string $scope): bool
+    {
+        return in_array($scope, $this->grantedScopes, true);
+    }
+
+    /**
+     * Set granted scopes (useful for testing)
+     */
+    public function setGrantedScopes(array $scopes): void
+    {
+        $this->grantedScopes = $scopes;
     }
 
     /**
@@ -131,6 +175,7 @@ class SpotifyService
             'access_token' => $this->accessToken,
             'refresh_token' => $this->refreshToken,
             'expires_at' => $this->expiresAt,
+            'scope' => implode(' ', $this->grantedScopes),
         ];
 
         // Ensure config directory exists (PHAR compatible path)

--- a/config/app.php
+++ b/config/app.php
@@ -55,6 +55,7 @@ return [
 
     'providers' => [
         App\Providers\AppServiceProvider::class,
+        App\Providers\AuthServiceProvider::class,
     ],
 
 ];

--- a/tests/Feature/AuthorizationTest.php
+++ b/tests/Feature/AuthorizationTest.php
@@ -1,0 +1,392 @@
+<?php
+
+use App\Services\SpotifyService;
+use Illuminate\Support\Facades\Gate;
+
+describe('Gate Authorization', function () {
+
+    describe('Play Command Authorization', function () {
+
+        test('play command requires user-modify-playback-state scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                ]);
+            });
+
+            $this->artisan('play', ['query' => 'test song'])
+                ->expectsOutput('❌ Missing required scope: user-modify-playback-state')
+                ->assertExitCode(1);
+        });
+
+        test('play command succeeds with proper scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+                $mock->shouldReceive('search')
+                    ->once()
+                    ->with('test song')
+                    ->andReturn([
+                        'uri' => 'spotify:track:123',
+                        'name' => 'Test Song',
+                        'artist' => 'Test Artist',
+                    ]);
+                $mock->shouldReceive('play')
+                    ->once()
+                    ->with('spotify:track:123', null);
+            });
+
+            $this->artisan('play', ['query' => 'test song'])
+                ->assertExitCode(0);
+        });
+
+        test('play command shows JSON error when unauthorized with --json flag', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([]);
+            });
+
+            $this->artisan('play', ['query' => 'test', '--json' => true])
+                ->expectsOutputToContain('"error":true')
+                ->expectsOutputToContain('user-modify-playback-state')
+                ->assertExitCode(1);
+        });
+    });
+
+    describe('Pause Command Authorization', function () {
+
+        test('pause command requires user-modify-playback-state scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                ]);
+            });
+
+            $this->artisan('pause')
+                ->expectsOutput('❌ Missing required scope: user-modify-playback-state')
+                ->assertExitCode(1);
+        });
+
+        test('pause command succeeds with proper scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+                $mock->shouldReceive('getCurrentPlayback')->andReturn([
+                    'name' => 'Test Song',
+                    'artist' => 'Test Artist',
+                    'progress_ms' => 60000,
+                ]);
+                $mock->shouldReceive('pause')->once();
+            });
+
+            $this->artisan('pause')
+                ->assertExitCode(0);
+        });
+    });
+
+    describe('Resume Command Authorization', function () {
+
+        test('resume command requires user-modify-playback-state scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([]);
+            });
+
+            $this->artisan('resume')
+                ->expectsOutput('❌ Missing required scope: user-modify-playback-state')
+                ->assertExitCode(1);
+        });
+
+        test('resume command succeeds with proper scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+                $mock->shouldReceive('resume')->once();
+                $mock->shouldReceive('getCurrentPlayback')->andReturn([
+                    'name' => 'Test Song',
+                    'artist' => 'Test Artist',
+                    'album' => 'Test Album',
+                ]);
+            });
+
+            $this->artisan('resume')
+                ->assertExitCode(0);
+        });
+    });
+
+    describe('Skip Command Authorization', function () {
+
+        test('skip command requires user-modify-playback-state scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([]);
+            });
+
+            $this->artisan('skip')
+                ->expectsOutput('❌ Missing required scope: user-modify-playback-state')
+                ->assertExitCode(1);
+        });
+
+        test('skip command succeeds with proper scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+                $mock->shouldReceive('getCurrentPlayback')->andReturn([
+                    'name' => 'Test Song',
+                    'artist' => 'Test Artist',
+                ]);
+                $mock->shouldReceive('next')->once();
+            });
+
+            $this->artisan('skip')
+                ->assertExitCode(0);
+        });
+    });
+
+    describe('Volume Command Authorization', function () {
+
+        test('volume command requires user-modify-playback-state scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([]);
+            });
+
+            $this->artisan('volume', ['level' => '50'])
+                ->expectsOutput('❌ Missing required scope: user-modify-playback-state')
+                ->assertExitCode(1);
+        });
+
+        test('volume command succeeds with proper scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+                $mock->shouldReceive('setVolume')->once()->with(50)->andReturn(true);
+            });
+
+            $this->artisan('volume', ['level' => '50'])
+                ->assertExitCode(0);
+        });
+    });
+
+    describe('Shuffle Command Authorization', function () {
+
+        test('shuffle command requires both read and modify playback scopes', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                ]);
+            });
+
+            $this->artisan('shuffle', ['state' => 'on'])
+                ->expectsOutput('❌ Missing required scope: user-read-playback-state, user-modify-playback-state')
+                ->assertExitCode(1);
+        });
+
+        test('shuffle command succeeds with proper scopes', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                    'user-modify-playback-state',
+                ]);
+                $mock->shouldReceive('getCurrentPlayback')->andReturn([
+                    'name' => 'Test Song',
+                    'artist' => 'Test Artist',
+                    'shuffle_state' => false,
+                ]);
+                $mock->shouldReceive('setShuffle')->once()->with(true)->andReturn(true);
+            });
+
+            $this->artisan('shuffle', ['state' => 'on'])
+                ->assertExitCode(0);
+        });
+    });
+
+    describe('Repeat Command Authorization', function () {
+
+        test('repeat command requires both read and modify playback scopes', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+            });
+
+            $this->artisan('repeat', ['state' => 'track'])
+                ->expectsOutput('❌ Missing required scope: user-read-playback-state, user-modify-playback-state')
+                ->assertExitCode(1);
+        });
+
+        test('repeat command succeeds with proper scopes', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                    'user-modify-playback-state',
+                ]);
+                $mock->shouldReceive('getCurrentPlayback')->andReturn([
+                    'name' => 'Test Song',
+                    'artist' => 'Test Artist',
+                    'repeat_state' => 'off',
+                ]);
+                $mock->shouldReceive('setRepeat')->once()->with('track')->andReturn(true);
+            });
+
+            $this->artisan('repeat', ['state' => 'track'])
+                ->assertExitCode(0);
+        });
+    });
+
+    describe('Current Command Authorization', function () {
+
+        test('current command requires read playback scopes', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+            });
+
+            $this->artisan('current')
+                ->expectsOutput('❌ Missing required scope: user-read-playback-state, user-read-currently-playing')
+                ->assertExitCode(1);
+        });
+
+        test('current command succeeds with proper scopes', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                    'user-read-currently-playing',
+                ]);
+                $mock->shouldReceive('getCurrentPlayback')->andReturn([
+                    'name' => 'Test Song',
+                    'artist' => 'Test Artist',
+                    'album' => 'Test Album',
+                    'progress_ms' => 60000,
+                    'duration_ms' => 180000,
+                    'is_playing' => true,
+                ]);
+            });
+
+            $this->artisan('current')
+                ->assertExitCode(0);
+        });
+    });
+
+    describe('Queue Command Authorization', function () {
+
+        test('queue command requires user-modify-playback-state scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([]);
+            });
+
+            $this->artisan('queue', ['query' => 'test song'])
+                ->expectsOutput('❌ Missing required scope: user-modify-playback-state')
+                ->assertExitCode(1);
+        });
+
+        test('queue command succeeds with proper scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+                $mock->shouldReceive('search')
+                    ->once()
+                    ->with('test song')
+                    ->andReturn([
+                        'uri' => 'spotify:track:123',
+                        'name' => 'Test Song',
+                        'artist' => 'Test Artist',
+                    ]);
+                $mock->shouldReceive('addToQueue')->once()->with('spotify:track:123');
+            });
+
+            $this->artisan('queue', ['query' => 'test song'])
+                ->assertExitCode(0);
+        });
+    });
+
+    describe('Devices Command Authorization', function () {
+
+        test('devices command requires user-read-playback-state scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([]);
+            });
+
+            $this->artisan('devices')
+                ->expectsOutput('❌ Missing required scope: user-read-playback-state')
+                ->assertExitCode(1);
+        });
+
+        test('devices command succeeds with proper scope', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                ]);
+                $mock->shouldReceive('getDevices')->andReturn([
+                    [
+                        'id' => 'device1',
+                        'name' => 'MacBook',
+                        'type' => 'Computer',
+                        'is_active' => true,
+                        'volume_percent' => 50,
+                    ],
+                ]);
+            });
+
+            $this->artisan('devices')
+                ->assertExitCode(0);
+        });
+    });
+
+    describe('Authorization with all scopes', function () {
+
+        test('commands work with all required scopes granted', function () {
+            $allScopes = [
+                'user-read-playback-state',
+                'user-modify-playback-state',
+                'user-read-currently-playing',
+                'streaming',
+                'playlist-read-private',
+                'playlist-read-collaborative',
+            ];
+
+            $this->mock(SpotifyService::class, function ($mock) use ($allScopes) {
+                $mock->shouldReceive('isConfigured')->andReturn(true);
+                $mock->shouldReceive('getGrantedScopes')->andReturn($allScopes);
+                $mock->shouldReceive('getCurrentPlayback')->andReturn([
+                    'name' => 'Test Song',
+                    'artist' => 'Test Artist',
+                    'album' => 'Test Album',
+                    'progress_ms' => 60000,
+                    'duration_ms' => 180000,
+                    'is_playing' => true,
+                    'shuffle_state' => false,
+                    'repeat_state' => 'off',
+                ]);
+            });
+
+            // Current command should work
+            $this->artisan('current')
+                ->assertExitCode(0);
+        });
+    });
+});

--- a/tests/Unit/AuthServiceProviderTest.php
+++ b/tests/Unit/AuthServiceProviderTest.php
@@ -1,0 +1,203 @@
+<?php
+
+use App\Providers\AuthServiceProvider;
+use App\Services\SpotifyService;
+use Illuminate\Support\Facades\Gate;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+describe('AuthServiceProvider', function () {
+
+    describe('Gate Definitions', function () {
+
+        test('defines spotify:play gate', function () {
+            expect(Gate::has('spotify:play'))->toBeTrue();
+        });
+
+        test('defines spotify:pause gate', function () {
+            expect(Gate::has('spotify:pause'))->toBeTrue();
+        });
+
+        test('defines spotify:resume gate', function () {
+            expect(Gate::has('spotify:resume'))->toBeTrue();
+        });
+
+        test('defines spotify:skip gate', function () {
+            expect(Gate::has('spotify:skip'))->toBeTrue();
+        });
+
+        test('defines spotify:volume gate', function () {
+            expect(Gate::has('spotify:volume'))->toBeTrue();
+        });
+
+        test('defines spotify:shuffle gate', function () {
+            expect(Gate::has('spotify:shuffle'))->toBeTrue();
+        });
+
+        test('defines spotify:repeat gate', function () {
+            expect(Gate::has('spotify:repeat'))->toBeTrue();
+        });
+
+        test('defines spotify:queue gate', function () {
+            expect(Gate::has('spotify:queue'))->toBeTrue();
+        });
+
+        test('defines spotify:current gate', function () {
+            expect(Gate::has('spotify:current'))->toBeTrue();
+        });
+
+        test('defines spotify:devices gate', function () {
+            expect(Gate::has('spotify:devices'))->toBeTrue();
+        });
+
+        test('defines spotify:player gate', function () {
+            expect(Gate::has('spotify:player'))->toBeTrue();
+        });
+    });
+
+    describe('Gate Authorization Logic', function () {
+
+        test('spotify:play returns true when user-modify-playback-state scope is granted', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+            });
+
+            expect(Gate::allows('spotify:play'))->toBeTrue();
+        });
+
+        test('spotify:play returns false when scope is not granted', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                ]);
+            });
+
+            expect(Gate::allows('spotify:play'))->toBeFalse();
+        });
+
+        test('spotify:shuffle requires both read and modify scopes', function () {
+            // Only read scope - should fail
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                ]);
+            });
+
+            expect(Gate::allows('spotify:shuffle'))->toBeFalse();
+
+            // Only modify scope - should fail
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+            });
+
+            expect(Gate::allows('spotify:shuffle'))->toBeFalse();
+
+            // Both scopes - should pass
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                    'user-modify-playback-state',
+                ]);
+            });
+
+            expect(Gate::allows('spotify:shuffle'))->toBeTrue();
+        });
+
+        test('spotify:current requires both user-read-playback-state and user-read-currently-playing', function () {
+            // Only one scope - should fail
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                ]);
+            });
+
+            expect(Gate::allows('spotify:current'))->toBeFalse();
+
+            // Both scopes - should pass
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                    'user-read-currently-playing',
+                ]);
+            });
+
+            expect(Gate::allows('spotify:current'))->toBeTrue();
+        });
+
+        test('returns false when no scopes are granted', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([]);
+            });
+
+            expect(Gate::allows('spotify:play'))->toBeFalse();
+            expect(Gate::allows('spotify:pause'))->toBeFalse();
+            expect(Gate::allows('spotify:current'))->toBeFalse();
+            expect(Gate::allows('spotify:shuffle'))->toBeFalse();
+        });
+
+        test('all gates pass with all scopes granted', function () {
+            $allScopes = [
+                'user-read-playback-state',
+                'user-modify-playback-state',
+                'user-read-currently-playing',
+                'streaming',
+                'playlist-read-private',
+                'playlist-read-collaborative',
+            ];
+
+            $this->mock(SpotifyService::class, function ($mock) use ($allScopes) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn($allScopes);
+            });
+
+            expect(Gate::allows('spotify:play'))->toBeTrue();
+            expect(Gate::allows('spotify:pause'))->toBeTrue();
+            expect(Gate::allows('spotify:resume'))->toBeTrue();
+            expect(Gate::allows('spotify:skip'))->toBeTrue();
+            expect(Gate::allows('spotify:volume'))->toBeTrue();
+            expect(Gate::allows('spotify:shuffle'))->toBeTrue();
+            expect(Gate::allows('spotify:repeat'))->toBeTrue();
+            expect(Gate::allows('spotify:queue'))->toBeTrue();
+            expect(Gate::allows('spotify:current'))->toBeTrue();
+            expect(Gate::allows('spotify:devices'))->toBeTrue();
+            expect(Gate::allows('spotify:player'))->toBeTrue();
+        });
+    });
+
+    describe('Scope Ability Mappings', function () {
+
+        test('read-playback ability maps to user-read-playback-state', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-playback-state',
+                ]);
+            });
+
+            expect(Gate::allows('read-playback'))->toBeTrue();
+        });
+
+        test('modify-playback ability maps to user-modify-playback-state', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-modify-playback-state',
+                ]);
+            });
+
+            expect(Gate::allows('modify-playback'))->toBeTrue();
+        });
+
+        test('read-currently-playing ability maps to user-read-currently-playing', function () {
+            $this->mock(SpotifyService::class, function ($mock) {
+                $mock->shouldReceive('getGrantedScopes')->andReturn([
+                    'user-read-currently-playing',
+                ]);
+            });
+
+            expect(Gate::allows('read-currently-playing'))->toBeTrue();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add Laravel Gate integration for OAuth scope-based authorization
- Create comprehensive Pest test suite for SpotifyService and commands
- All commands now verify required OAuth scopes before execution

## Changes

### Gate Authorization
- New `AuthServiceProvider` with Gate definitions for all Spotify commands
- Each command maps to required OAuth scopes (e.g., `spotify:play` → `user-modify-playback-state`)
- Composite gates for commands requiring multiple scopes (shuffle, repeat, current, player)

### SpotifyService Enhancements
- Extract and store OAuth scopes from token data
- New methods: `getGrantedScopes()`, `hasScope()`, `setGrantedScopes()`
- Scopes now persisted in token file

### Command Authorization
- New `ChecksAuthorization` trait for all commands
- `authorizeOrFail()` method provides user-friendly error messages
- JSON error output support when `--json` flag is used
- Commands affected: play, pause, resume, skip, volume, shuffle, repeat, queue, current, devices, player

### Test Suite
- 8 new scope management tests in `SpotifyServiceTest.php`
- New `AuthServiceProviderTest.php` with Gate definition and logic tests
- New `AuthorizationTest.php` with feature tests for all commands

## Test plan
- [ ] Run existing tests: `./vendor/bin/pest`
- [ ] Verify authorization errors with missing scopes
- [ ] Verify commands work with proper scopes granted
- [ ] Test JSON output mode for authorization errors

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)