### PR TITLE
fix: remove hardcoded paths from nowplaying scripts

### DIFF
--- a/bin/nowplaying-bridge.py
+++ b/bin/nowplaying-bridge.py
@@ -8,6 +8,8 @@ Usage:
     spotify watch --json --interval=3 | python3 nowplaying-bridge.py
 """
 
+import os
+import shutil
 import sys
 import json
 import subprocess
@@ -19,8 +21,16 @@ from Foundation import NSObject, NSRunLoop, NSDate
 from AppKit import NSApplication
 import MediaPlayer
 
-SPOTIFY_CLI = "/Users/jordanpartridge/packages/the-shit/spotify-cli/spotify"
-PHP_BIN = "/Users/jordanpartridge/Library/Application Support/Herd/bin/php"
+# Derive paths dynamically so the bridge works on any machine.
+# SCRIPT_DIR = the directory this script lives in (i.e. <project>/bin/)
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_DIR = os.path.dirname(SCRIPT_DIR)
+
+# The 'spotify' Laravel Zero binary lives at the project root.
+SPOTIFY_CLI = os.path.join(PROJECT_DIR, "spotify")
+
+# Find PHP on the system PATH — works with Herd, Homebrew, or any other install.
+PHP_BIN = shutil.which("php") or "php"
 
 
 class NowPlayingBridge(NSObject):

--- a/bin/nowplaying-start.sh
+++ b/bin/nowplaying-start.sh
@@ -2,9 +2,33 @@
 # nowplaying-start.sh
 # Starts the Spotify → macOS NowPlaying bridge
 
-PHP="/Users/jordanpartridge/Library/Application Support/Herd/bin/php"
-SPOTIFY="/Users/jordanpartridge/packages/the-shit/spotify-cli/spotify"
-PYTHON="/opt/homebrew/Caskroom/miniconda/base/bin/python3"
-BRIDGE="/Users/jordanpartridge/packages/the-shit/spotify-cli/bin/nowplaying-bridge.py"
+# Resolve the real directory of this script, even through symlinks.
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Find binaries on PATH — works with Herd, Homebrew, system PHP, etc.
+PHP="$(command -v php)"
+PYTHON="$(command -v python3)"
+
+# Project-relative paths for the CLI binary and bridge script.
+SPOTIFY="$PROJECT_DIR/spotify"
+BRIDGE="$SCRIPT_DIR/nowplaying-bridge.py"
+
+if [ -z "$PHP" ]; then
+    echo "Error: php not found on PATH" >&2
+    exit 1
+fi
+if [ -z "$PYTHON" ]; then
+    echo "Error: python3 not found on PATH" >&2
+    exit 1
+fi
+if [ ! -f "$SPOTIFY" ]; then
+    echo "Error: spotify binary not found at $SPOTIFY" >&2
+    exit 1
+fi
+if [ ! -f "$BRIDGE" ]; then
+    echo "Error: nowplaying-bridge.py not found at $BRIDGE" >&2
+    exit 1
+fi
 
 exec "$PHP" "$SPOTIFY" watch --json --interval=3 | exec "$PYTHON" "$BRIDGE"


### PR DESCRIPTION
## Summary
- Replaces hardcoded `/Users/jordan` paths in `bin/nowplaying-bridge.py` with dynamic `__file__`-based resolution
- Replaces hardcoded paths in `bin/nowplaying-start.sh` with `$HOME` and script directory resolution

## Test plan
- [ ] Run `spotify nowplaying` and verify the bridge script starts correctly
- [ ] Confirm no hardcoded paths remain in `bin/nowplaying-bridge.py` or `bin/nowplaying-start.sh`
- [ ] Test on a fresh clone to verify paths resolve correctly

Closes #14