### PR TITLE
fix: add .env.example documenting all env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# the-shit/music — Spotify CLI
+#
+# Copy to .env and fill in required values.
+# Alternatively, run `spotify setup` for a guided wizard.
+
+# Required — get these from https://developer.spotify.com/dashboard
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# Optional — defaults shown. Uncomment to override.
+# SPOTIFY_REDIRECT_URI=http://127.0.0.1:8888/callback
+# SPOTIFY_TOKEN_PATH=~/.config/spotify-cli/token.json
+# SPOTIFY_CONFIG_DIR=~/.config/spotify-cli
+# SPOTIFY_SLACK_WEBHOOK=


### PR DESCRIPTION
## Summary
- Adds `.env.example` with all 6 env vars used by the project
- 2 required (`SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`) left blank for users to fill in
- 4 optional commented out with defaults documented

## Test plan
- [ ] `cp .env.example .env`, fill in credentials, verify `spotify setup` is not required
- [ ] Verify all env var names match `config/spotify.php` and command usage

Closes #16