### PR TITLE
fix: remove experimental label from daemon, add --audio-device option

### DIFF
--- a/app/Commands/DaemonCommand.php
+++ b/app/Commands/DaemonCommand.php
@@ -14,9 +14,9 @@ class DaemonCommand extends Command
 {
     use RequiresSpotifyConfig;
 
-    protected $signature = 'daemon {action : start, stop, or status} {--name= : Device name for Spotify Connect}';
+    protected $signature = 'daemon {action : start, stop, or status} {--name= : Device name for Spotify Connect} {--audio-device= : Audio output device (e.g. "Wave Link Stream")}';
 
-    protected $description = 'Manage the Spotify daemon for terminal playback (experimental)';
+    protected $description = 'Manage the Spotify daemon for terminal playback';
 
     private string $pidFile;
 
@@ -32,12 +32,6 @@ class DaemonCommand extends Command
 
     public function handle()
     {
-        warning('⚠️  Daemon mode is experimental and finicky on macOS');
-        warning('💡 Try using existing devices instead:');
-        warning('   spotify play "song" --device="Your Device Name"');
-        warning('   spotify devices  # list available devices');
-        $this->newLine();
-
         $action = $this->argument('action');
 
         return match ($action) {
@@ -142,6 +136,11 @@ class DaemonCommand extends Command
                   "bitrate = 320\n".
                   "volume_normalisation = true\n".
                   "cache_path = \"{$configDir}/cache\"\n";
+
+        $audioDevice = $this->option('audio-device');
+        if ($audioDevice) {
+            $config .= "device = \"{$audioDevice}\"\n";
+        }
 
         file_put_contents($configFile, $config);
 

--- a/tests/Feature/DaemonCommandTest.php
+++ b/tests/Feature/DaemonCommandTest.php
@@ -144,7 +144,7 @@ describe('DaemonCommand', function () {
 
         it('has correct description', function () {
             $command = $this->app->make(DaemonCommand::class);
-            expect($command->getDescription())->toBe('Manage the Spotify daemon for terminal playback (experimental)');
+            expect($command->getDescription())->toBe('Manage the Spotify daemon for terminal playback');
         });
 
         it('requires action argument', function () {


### PR DESCRIPTION
## Summary
- Remove experimental warnings from the daemon command -- it's been stable enough in daily use to drop the guardrails
- Add `--audio-device` option so spotifyd can route playback through virtual audio devices (e.g. Wave Link Stream, BlackHole, Loopback)
- Update test expectation to match the new description

## Details
The daemon command previously printed experimental warnings on every invocation and tagged its description with `(experimental)`. After sustained use without issues, these have been removed.

The new `--audio-device` option writes a `device = "..."` line into the generated spotifyd config, enabling routing through Wave Link or other virtual audio interfaces. This is useful for streamers and producers who need Spotify audio on a specific bus.

## Test plan
- [ ] `spotify daemon start` no longer prints experimental warnings
- [ ] `spotify daemon start --audio-device="Wave Link Stream"` writes `device = "Wave Link Stream"` to the spotifyd config
- [ ] `spotify daemon start` without `--audio-device` does not include a `device` line in the config
- [ ] `pest --filter=DaemonCommand` passes