### PR TITLE
feat(autopilot): smart discovery + media bridge progress fix

### DIFF
--- a/app/Commands/QueueFillCommand.php
+++ b/app/Commands/QueueFillCommand.php
@@ -68,11 +68,11 @@ class QueueFillCommand extends Command
                 $existingUris[] = $recent['uri'] ?? '';
             }
 
-            // Let Spotify's algorithm pick the tracks
+            // getRecommendations auto-falls through to smart discovery
+            // when the deprecated /v1/recommendations endpoint returns empty
             $recommendations = $spotify->getRecommendations($seedTrackIds, $seedArtistIds, $needed + 5);
 
-            // Fall back to search-based discovery if recommendations API returns empty
-            // (the /v1/recommendations endpoint was deprecated in Nov 2024)
+            // If still empty, fall back to improved related tracks
             if (empty($recommendations) && $currentlyPlaying) {
                 $artistName = $currentlyPlaying['artists'][0]['name'] ?? null;
                 $trackName = $currentlyPlaying['name'] ?? null;


### PR DESCRIPTION
## Summary

### Smart Discovery (replaces deprecated recommendations)
- **Root cause**: Spotify deprecated `/v1/recommendations` for dev-mode apps (Nov 2024)
- **New `getSmartRecommendations()`** combines 5 strategies: top tracks, top artists, genre search, Discover Weekly/Daily Mixes, similar-artist queries
- **Improved `getRelatedTracks()`** broadened from 2 to 4 search strategies
- **Time-bounded session dedup** — 30-min sliding window replaces unbounded growth

### Media Bridge Progress Fix (Closes #43)
- Progress bar now advances smoothly between polls (200ms latency compensation)
- Seek via Control Center scrubber works instantly (new `spotify seek` command)
- Reduced log noise — only logs on track/state changes, not every 5s poll
- Toggle play/pause uses cached state for instant visual feedback
- Pause freezes progress bar at interpolated position

## Test plan
- [x] All 466 tests pass
- [x] Autopilot live tested through multiple track changes — diverse cross-genre refills
- [x] Media bridge recompiled and verified running
- [x] Seek command tested: `spotify seek 1:30`, `spotify seek +30`, `spotify seek -5`
- [x] Control Center progress bar verified smooth after bridge restart