### PR TITLE
fix(media-bridge): smooth progress tracking and add seek command

### DIFF
--- a/app/Commands/SeekCommand.php
+++ b/app/Commands/SeekCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Commands;
+
+use App\Commands\Concerns\RequiresSpotifyConfig;
+use App\Services\SpotifyService;
+use LaravelZero\Framework\Commands\Command;
+
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\info;
+
+class SeekCommand extends Command
+{
+    use RequiresSpotifyConfig;
+
+    protected $signature = 'seek
+                            {position : Position in ms, or M:SS format (e.g. 1:30), or +/-seconds (e.g. +10, -5)}';
+
+    protected $description = 'Seek to a position in the current track';
+
+    public function handle(SpotifyService $spotify)
+    {
+        if (! $this->ensureConfigured()) {
+            return self::FAILURE;
+        }
+
+        try {
+            $input = $this->argument('position');
+            $positionMs = $this->parsePosition($spotify, $input);
+
+            $spotify->seek($positionMs);
+
+            $seconds = intdiv($positionMs, 1000);
+            $formatted = sprintf('%d:%02d', intdiv($seconds, 60), $seconds % 60);
+            info("Seeked to {$formatted}");
+
+            return self::SUCCESS;
+        } catch (\Exception $e) {
+            error('Failed to seek: '.$e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function parsePosition(SpotifyService $spotify, string $input): int
+    {
+        // Relative seek: +10 or -5 (seconds)
+        if (preg_match('/^([+-])(\d+)$/', $input, $m)) {
+            $current = $spotify->getCurrentPlayback();
+            $currentMs = $current['progress_ms'] ?? 0;
+            $deltaMs = (int) $m[2] * 1000;
+
+            return max(0, $m[1] === '+' ? $currentMs + $deltaMs : $currentMs - $deltaMs);
+        }
+
+        // M:SS format
+        if (preg_match('/^(\d+):(\d{1,2})$/', $input, $m)) {
+            return ((int) $m[1] * 60 + (int) $m[2]) * 1000;
+        }
+
+        // Raw milliseconds
+        if (ctype_digit($input)) {
+            return (int) $input;
+        }
+
+        throw new \InvalidArgumentException("Invalid position: {$input}. Use ms, M:SS, +seconds, or -seconds.");
+    }
+}

--- a/app/Services/SpotifyService.php
+++ b/app/Services/SpotifyService.php
@@ -878,6 +878,22 @@ class SpotifyService
     }
 
     /**
+     * Seek to a position in the current track
+     */
+    public function seek(int $positionMs): void
+    {
+        $this->requireAuth();
+
+        $response = Http::withToken($this->accessToken)
+            ->put($this->baseUri.'me/player/seek?position_ms='.$positionMs);
+
+        if (! $response->successful()) {
+            $error = $response->json();
+            throw new \Exception($error['error']['message'] ?? 'Failed to seek');
+        }
+    }
+
+    /**
      * Set shuffle state
      */
     public function setShuffle(bool $state): bool


### PR DESCRIPTION
## Summary

- Progress bar in Control Center now advances smoothly between polls (200ms latency compensation for macOS extrapolation)
- Seek via Control Center scrubber gives instant visual feedback before the API round-trip
- Toggle play/pause uses cached state — no extra API call, instant UI response
- Pause freezes progress bar at interpolated position instead of stale poll value
- Reduced log noise — only logs on track/state changes, not every 5s poll
- New `spotify seek` command supports ms, M:SS, +/-seconds (e.g. `seek 1:30`, `seek +10`, `seek -5`)

Closes #43

## Test plan

- [x] All 466 tests pass
- [x] Media bridge recompiled and verified running
- [x] `spotify seek 1:30` / `spotify seek +30` / `spotify seek -5` all work
- [x] Control Center progress bar smooth after bridge restart