### PR TITLE
chore(ci): disable Sentinel auto-merge on protected master

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           check: certify
           coverage-threshold: 50
-          auto-merge: true
+          auto-merge: false
           coverage-comment: true
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- disable Sentinel Gate auto-merge in workflow config so failing required checks can no longer be bypassed by workflow automation
- pair this with repository branch protection requiring both `Sentinel Gate` and `Vibe Check` on `master`

## Testing
- config-only change (no runtime code path)