### PR TITLE
feat(autopilot): preserve mood tuning across smart discovery fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ spotify player     # Launch interactive TUI player
 
 - **Playback** — play, pause, skip, volume, shuffle, repeat
 - **Queue** — add tracks, view upcoming, auto-fill from recommendations
-- **Discovery** — search, mood queues (chill / flow / hype), top tracks
+- **Discovery** — search, mood queues, smart recommendations, top tracks
 - **Interactive Player** — TUI with progress bar and keyboard controls
 - **Daemon** — background playback via spotifyd, macOS media key integration
 - **Services** — spotifyd, Swift media bridge, autopilot — all managed via launchd
@@ -79,7 +79,7 @@ spotify autopilot --status                 # Check status
 spotify autopilot --uninstall              # Remove
 ```
 
-Watches for track changes and auto-refills the queue when it drops below a threshold. Supports mood-based recommendations (`chill` / `flow` / `hype`).
+Watches for track changes and auto-refills the queue when it drops below a threshold. Supports mood presets: `chill`, `flow`, `hype`, `focus`, `party`, `upbeat`, `melancholy`, `ambient`, `workout`, `sleep`.
 
 ### Service overview
 

--- a/config/autopilot.php
+++ b/config/autopilot.php
@@ -1,0 +1,71 @@
+<?php
+
+return [
+    'mood_presets' => [
+        'chill' => [
+            'target_energy' => 0.3,
+            'target_valence' => 0.5,
+            'target_tempo' => 90,
+            'target_danceability' => 0.5,
+            'target_acousticness' => 0.6,
+        ],
+        'flow' => [
+            'target_energy' => 0.6,
+            'target_valence' => 0.6,
+            'target_tempo' => 120,
+            'target_danceability' => 0.6,
+            'target_instrumentalness' => 0.2,
+        ],
+        'hype' => [
+            'target_energy' => 0.9,
+            'target_valence' => 0.8,
+            'target_tempo' => 140,
+            'target_danceability' => 0.85,
+        ],
+        'focus' => [
+            'target_energy' => 0.45,
+            'target_valence' => 0.4,
+            'target_tempo' => 105,
+            'target_instrumentalness' => 0.7,
+            'target_speechiness' => 0.08,
+        ],
+        'party' => [
+            'target_energy' => 0.92,
+            'target_valence' => 0.85,
+            'target_tempo' => 128,
+            'target_danceability' => 0.9,
+        ],
+        'upbeat' => [
+            'target_energy' => 0.78,
+            'target_valence' => 0.82,
+            'target_tempo' => 124,
+            'target_danceability' => 0.78,
+        ],
+        'melancholy' => [
+            'target_energy' => 0.4,
+            'target_valence' => 0.2,
+            'target_tempo' => 95,
+            'target_acousticness' => 0.45,
+        ],
+        'ambient' => [
+            'target_energy' => 0.2,
+            'target_valence' => 0.4,
+            'target_tempo' => 78,
+            'target_acousticness' => 0.7,
+            'target_instrumentalness' => 0.85,
+        ],
+        'workout' => [
+            'target_energy' => 0.95,
+            'target_valence' => 0.7,
+            'target_tempo' => 150,
+            'target_danceability' => 0.82,
+        ],
+        'sleep' => [
+            'target_energy' => 0.12,
+            'target_valence' => 0.28,
+            'target_tempo' => 65,
+            'target_acousticness' => 0.82,
+            'target_instrumentalness' => 0.9,
+        ],
+    ],
+];

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -89,6 +89,7 @@
                     <tr><td><code>spotify chill</code></td><td>Queue chill, relaxing music</td></tr>
                     <tr><td><code>spotify flow</code></td><td>Queue focus/flow state music for deep work</td></tr>
                     <tr><td><code>spotify hype</code></td><td>Queue high-energy hype tracks</td></tr>
+                    <tr><td><code>spotify autopilot --mood=focus</code></td><td>Auto-refill queue using mood presets (chill, flow, hype, focus, party, upbeat, melancholy, ambient, workout, sleep)</td></tr>
                 </tbody>
             </table>
         </div>
@@ -123,6 +124,7 @@
                 <thead><tr><th>Command</th><th>Description</th></tr></thead>
                 <tbody>
                     <tr><td><code>spotify daemon</code></td><td>Manage the Spotify daemon for terminal playback</td></tr>
+                    <tr><td><code>spotify autopilot</code></td><td>Run queue autopilot, or manage its LaunchAgent with --install/--status/--uninstall</td></tr>
                     <tr><td><code>spotify nowplaying</code></td><td>Sync playback to macOS Control Center and enable media keys</td></tr>
                     <tr><td><code>spotify watch</code></td><td>Watch playback and stream events (track changes, play/pause)</td></tr>
                     <tr><td><code>spotify event:emit</code></td><td>Emit an event to the event bus</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,7 @@
             </div>
             <div class="feature-card">
                 <h3>Discovery</h3>
-                <p>AI-friendly search, mood queues (chill, flow, hype), and recommendations powered by your listening history.</p>
+                <p>AI-friendly search, mood queues, and autopilot presets (chill, flow, hype, focus, party, upbeat, melancholy, ambient, workout, sleep) powered by your listening history.</p>
             </div>
             <div class="feature-card">
                 <h3>Queue Management</h3>

--- a/tests/Feature/AutopilotCommandTest.php
+++ b/tests/Feature/AutopilotCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Commands\AutopilotCommand;
+use Illuminate\Support\Facades\Config;
+
+describe('AutopilotCommand', function () {
+
+    beforeEach(function () {
+        Config::set('autopilot.mood_presets', config('autopilot.mood_presets'));
+        $this->command = $this->app->make(AutopilotCommand::class);
+    });
+
+    it('uses mood presets from config', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method = $reflection->getMethod('moodPresets');
+        $method->setAccessible(true);
+
+        $presets = $method->invoke($this->command);
+
+        expect($presets)->toHaveCount(10);
+        expect($presets)->toHaveKeys(['flow', 'focus', 'sleep']);
+        expect($presets['flow'])->toHaveKey('target_energy');
+    });
+
+    it('builds track and artist seeds from current and recent playback', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method = $reflection->getMethod('buildRecommendationSeeds');
+        $method->setAccessible(true);
+
+        $current = [
+            'uri' => 'spotify:track:current123',
+            'artist_id' => 'artist_current',
+        ];
+
+        $recent = [
+            ['uri' => 'spotify:track:recent1', 'artist_id' => 'artist_recent_1'],
+            ['uri' => 'spotify:track:recent2', 'artist_id' => 'artist_recent_2'],
+            ['uri' => 'spotify:track:recent3', 'artist_id' => 'artist_recent_3'],
+            ['uri' => 'spotify:track:recent4', 'artist_id' => 'artist_recent_4'],
+            ['uri' => 'spotify:track:recent5', 'artist_id' => 'artist_recent_5'],
+        ];
+
+        [$trackSeeds, $artistSeeds] = $method->invoke($this->command, $current, $recent);
+
+        expect($trackSeeds)->toBe(['current123', 'recent1', 'recent2']);
+        expect($artistSeeds)->toBe([
+            'artist_current',
+            'artist_recent_1',
+            'artist_recent_2',
+            'artist_recent_3',
+            'artist_recent_4',
+        ]);
+    });
+
+    it('parses launchctl pid output robustly', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method = $reflection->getMethod('parseLaunchctlPid');
+        $method->setAccessible(true);
+
+        $valid = $method->invoke($this->command, '"PID" = 12345;');
+        $invalid = $method->invoke($this->command, 'no pid here');
+        $zero = $method->invoke($this->command, '"PID" = 0;');
+
+        expect($valid)->toBe(12345);
+        expect($invalid)->toBeNull();
+        expect($zero)->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- close issue #49 by preserving mood intent when `/recommendations` returns empty or lacks seeds, carrying audio-feature context into smart discovery fallback
- move autopilot mood presets into `config/autopilot.php`, validate mood consistently (interactive + install paths), and improve seed quality with artist IDs from current/recent playback
- harden autopilot daemon status detection and document the expanded autopilot mood preset behavior in README and docs pages

## Testing
- ./vendor/bin/pest tests/Unit/SpotifyServiceDiscoveryTest.php tests/Feature/AutopilotCommandTest.php tests/Feature/QueueFillCommandTest.php