### PR TITLE
Solo cockpit, find/pulse commands, and player UI polish

### DIFF
--- a/app/Commands/Concerns/RendersPlayback.php
+++ b/app/Commands/Concerns/RendersPlayback.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Commands\Concerns;
+
+/**
+ * Reusable terminal-rendering helpers for playback displays.
+ *
+ * Extracted from PlayerCommand so observability commands (pulse, marquee)
+ * can share the exact same progress bar, volume meter, and mode glyphs.
+ */
+trait RendersPlayback
+{
+    protected function formatProgress(int $progressMs, int $durationMs): string
+    {
+        $progressSec = floor($progressMs / 1000);
+        $durationSec = floor($durationMs / 1000);
+
+        $progressMin = floor($progressSec / 60);
+        $progressSec %= 60;
+
+        $durationMin = floor($durationSec / 60);
+        $durationSec %= 60;
+
+        $percentage = $durationMs > 0 ? ($progressMs / $durationMs) : 0;
+        $barLength = 30;
+        $filled = floor($percentage * $barLength);
+
+        $bar = str_repeat('━', (int) $filled).'●'.str_repeat('━', (int) ($barLength - $filled - 1));
+
+        return sprintf(
+            '%s %s %d:%02d/%d:%02d',
+            $progressMs < $durationMs ? '▶️' : '⏸️',
+            $bar,
+            $progressMin, $progressSec,
+            $durationMin, $durationSec
+        );
+    }
+
+    protected function formatVolume(int $volume): string
+    {
+        $icon = match (true) {
+            $volume === 0 => '🔇',
+            $volume <= 33 => '🔈',
+            $volume <= 66 => '🔉',
+            default => '🔊'
+        };
+
+        $barLength = 20;
+        $filled = floor($volume * $barLength / 100);
+        $bar = str_repeat('▓', (int) $filled).str_repeat('░', (int) ($barLength - $filled));
+
+        return sprintf('%s %s %d%%', $icon, $bar, $volume);
+    }
+
+    protected function formatPlaybackModes(bool $shuffle, string $repeat): string
+    {
+        $modes = [];
+
+        if ($shuffle) {
+            $modes[] = '🔀 Shuffle';
+        }
+
+        if ($repeat !== 'off') {
+            $repeatIcon = $repeat === 'track' ? '🔂' : '🔁';
+            $repeatText = $repeat === 'track' ? 'Repeat Track' : 'Repeat All';
+            $modes[] = $repeatIcon.' '.$repeatText;
+        }
+
+        return $modes !== [] ? implode('  ', $modes) : '';
+    }
+
+    /**
+     * Terminal display width of a string. mb_strwidth() reports the columns a
+     * monospace terminal actually uses: East-Asian-Wide emoji (🎵 👤 💿 🔊) = 2,
+     * and ambiguous glyphs incl. variation-selector symbols (▶️ ⏸️) = 1, which
+     * matches how these terminals render them (the U+FE0F itself is zero-width).
+     * Emoji width is ultimately terminal/font-dependent; this is the common case.
+     */
+    protected function displayWidth(string $text): int
+    {
+        return mb_strwidth($text);
+    }
+
+    /**
+     * Right-pad to a target display width (not byte/char count), so box borders
+     * line up regardless of emoji. The inverse of sprintf('%-Ns'), which pads by
+     * bytes and ruins alignment for multibyte/emoji content.
+     */
+    protected function padRight(string $text, int $width): string
+    {
+        return $text.str_repeat(' ', max(0, $width - $this->displayWidth($text)));
+    }
+
+    protected function clearScreen(): void
+    {
+        // Clear screen for better display (works on Unix-like systems)
+        if (PHP_OS_FAMILY !== 'Windows') {
+            system('clear');
+        }
+    }
+}

--- a/app/Commands/DaemonCommand.php
+++ b/app/Commands/DaemonCommand.php
@@ -782,7 +782,7 @@ XML;
             return null;
         }
 
-        $bytes = trim((string) shell_exec("du -sk ".escapeshellarg($path)." 2>/dev/null | cut -f1"));
+        $bytes = trim((string) shell_exec('du -sk '.escapeshellarg($path).' 2>/dev/null | cut -f1'));
 
         if ($bytes === '' || $bytes === '0') {
             return 0.0;

--- a/app/Commands/FindCommand.php
+++ b/app/Commands/FindCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Commands;
+
+use App\Commands\Concerns\RequiresSpotifyConfig;
+use App\Services\SpotifyDiscoveryService;
+use App\Services\SpotifyPlayerService;
+use LaravelZero\Framework\Commands\Command;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\pause;
+use function Laravel\Prompts\search;
+use function Laravel\Prompts\warning;
+
+class FindCommand extends Command
+{
+    use RequiresSpotifyConfig;
+
+    protected $signature = 'find
+                            {query? : Optional initial search term to seed the typeahead}
+                            {--queue : Add picks to the queue instead of playing immediately}';
+
+    protected $description = 'Fuzzy typeahead search and play (or queue) tracks on Spotify';
+
+    public function handle(SpotifyPlayerService $player, SpotifyDiscoveryService $discovery): int
+    {
+        if (! $this->ensureConfigured()) {
+            return self::FAILURE;
+        }
+
+        // Seed the first search with the optional query argument, then drop it
+        // so subsequent loop iterations start from a blank typeahead.
+        $seed = (string) $this->argument('query');
+
+        do {
+            $uri = search(
+                label: '🔎 Search Spotify',
+                options: function (string $value) use ($discovery, $seed): array {
+                    $query = strlen($value) < 2 ? $seed : $value;
+
+                    if (strlen($query) < 2) {
+                        return [];
+                    }
+
+                    $options = [];
+                    foreach ($discovery->searchMultiple($query, 'track', 12) as $track) {
+                        $options[$track['uri']] = sprintf(
+                            '🎵 %s — %s (%s)',
+                            $track['name'],
+                            $track['artist'] ?? 'Unknown',
+                            $track['album'] ?? 'Unknown',
+                        );
+                    }
+
+                    return $options;
+                },
+                placeholder: 'Type a song, artist, or album…',
+                scroll: 12,
+            );
+
+            $seed = '';
+
+            if (! $uri) {
+                warning('No track selected.');
+
+                break;
+            }
+
+            $this->playOrQueue($player, $uri);
+
+            pause();
+        } while (confirm(label: 'Search for another?', default: false));
+
+        return self::SUCCESS;
+    }
+
+    private function playOrQueue(SpotifyPlayerService $player, string $uri): void
+    {
+        $queue = $this->option('queue') || confirm(
+            label: 'Add to queue instead of playing now?',
+            default: false,
+        );
+
+        try {
+            if ($queue) {
+                $player->addToQueue($uri);
+                info("➕ Added to queue: {$uri}");
+            } else {
+                $player->play($uri);
+                info("▶️  Playing: {$uri}");
+            }
+        } catch (\Throwable $e) {
+            if (str_contains(strtolower($e->getMessage()), 'device')) {
+                warning('No active Spotify device found.');
+                info('💡 Run "spotify devices" to see and pick a device, then try again.');
+            } else {
+                warning('Could not complete that action: '.$e->getMessage());
+            }
+        }
+    }
+}

--- a/app/Commands/HistoryBackfillCommand.php
+++ b/app/Commands/HistoryBackfillCommand.php
@@ -68,7 +68,7 @@ class HistoryBackfillCommand extends Command
                 $this->line("  {$data['artist']} — {$data['track']} ({$event['event']})");
             }
             if ($count > 10) {
-                $this->line("  ... and ".($count - 10)." more");
+                $this->line('  ... and '.($count - 10).' more');
             }
             warning('Dry run — no events written');
 

--- a/app/Commands/PlayerCommand.php
+++ b/app/Commands/PlayerCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\RendersPlayback;
 use App\Commands\Concerns\RequiresSpotifyConfig;
 use App\Services\SpotifyDiscoveryService;
 use App\Services\SpotifyPlayerService;
@@ -15,6 +16,7 @@ use function Laravel\Prompts\warning;
 
 class PlayerCommand extends Command
 {
+    use RendersPlayback;
     use RequiresSpotifyConfig;
 
     protected $signature = 'player';
@@ -105,26 +107,29 @@ class PlayerCommand extends Command
     {
         $this->newLine();
         $this->line('┌─────────────────────────────────────────────────┐');
-        $this->line('│ 🎵 Now Playing                                  │');
+        // Pad to display width first, then wrap in style tags — tags render as
+        // zero-width ANSI, so padding must be measured on the bare text.
+        $this->line('│ <fg=cyan;options=bold>'.$this->padRight('🎵 Now Playing', 47).'</> │');
         $this->line('├─────────────────────────────────────────────────┤');
 
         // Track info
-        $track = substr($current['name'], 0, 40);
-        $artist = substr($current['artist'], 0, 40);
-        $album = substr($current['album'], 0, 40);
+        $track = mb_substr($current['name'], 0, 40);
+        $artist = mb_substr($current['artist'], 0, 40);
+        $album = mb_substr($current['album'], 0, 40);
 
-        $this->line(sprintf('│ %-47s │', $track));
-        $this->line(sprintf('│ %s %-46s │', '👤', $artist));
-        $this->line(sprintf('│ %s %-46s │', '💿', $album));
+        // Track title is the primary datum — bold it so it anchors the box.
+        $this->line('│ <options=bold>'.$this->padRight($track, 47).'</> │');
+        $this->line('│ '.$this->padRight('👤 '.$artist, 47).' │');
+        $this->line('│ '.$this->padRight('💿 '.$album, 47).' │');
 
         // Progress bar
         $progress = $this->formatProgress($current['progress_ms'], $current['duration_ms']);
-        $this->line(sprintf('│ %-47s │', $progress));
+        $this->line('│ '.$this->padRight($progress, 47).' │');
 
         // Volume if available
         if (isset($current['device']['volume_percent'])) {
             $volume = $this->formatVolume($current['device']['volume_percent']);
-            $this->line(sprintf('│ %-47s │', $volume));
+            $this->line('│ '.$this->padRight($volume, 47).' │');
         }
 
         // Playback modes
@@ -133,70 +138,11 @@ class PlayerCommand extends Command
             $current['repeat_state'] ?? 'off'
         );
         if ($modes !== '' && $modes !== '0') {
-            $this->line(sprintf('│ %-47s │', $modes));
+            $this->line('│ '.$this->padRight($modes, 47).' │');
         }
 
         $this->line('└─────────────────────────────────────────────────┘');
         $this->newLine();
-    }
-
-    private function formatProgress(int $progressMs, int $durationMs): string
-    {
-        $progressSec = floor($progressMs / 1000);
-        $durationSec = floor($durationMs / 1000);
-
-        $progressMin = floor($progressSec / 60);
-        $progressSec %= 60;
-
-        $durationMin = floor($durationSec / 60);
-        $durationSec %= 60;
-
-        $percentage = $durationMs > 0 ? ($progressMs / $durationMs) : 0;
-        $barLength = 30;
-        $filled = floor($percentage * $barLength);
-
-        $bar = str_repeat('━', (int) $filled).'●'.str_repeat('━', (int) ($barLength - $filled - 1));
-
-        return sprintf(
-            '%s %s %d:%02d/%d:%02d',
-            $progressMs < $durationMs ? '▶️' : '⏸️',
-            $bar,
-            $progressMin, $progressSec,
-            $durationMin, $durationSec
-        );
-    }
-
-    private function formatVolume(int $volume): string
-    {
-        $icon = match (true) {
-            $volume === 0 => '🔇',
-            $volume <= 33 => '🔈',
-            $volume <= 66 => '🔉',
-            default => '🔊'
-        };
-
-        $barLength = 20;
-        $filled = floor($volume * $barLength / 100);
-        $bar = str_repeat('▓', (int) $filled).str_repeat('░', (int) ($barLength - $filled));
-
-        return sprintf('%s %s %d%%', $icon, $bar, $volume);
-    }
-
-    private function formatPlaybackModes(bool $shuffle, string $repeat): string
-    {
-        $modes = [];
-
-        if ($shuffle) {
-            $modes[] = '🔀 Shuffle';
-        }
-
-        if ($repeat !== 'off') {
-            $repeatIcon = $repeat === 'track' ? '🔂' : '🔁';
-            $repeatText = $repeat === 'track' ? 'Repeat Track' : 'Repeat All';
-            $modes[] = $repeatIcon.' '.$repeatText;
-        }
-
-        return $modes !== [] ? implode('  ', $modes) : '';
     }
 
     private function getControlOptions(bool $isPlaying): array
@@ -503,13 +449,5 @@ class PlayerCommand extends Command
         };
 
         info($message);
-    }
-
-    private function clearScreen(): void
-    {
-        // Clear screen for better display (works on Unix-like systems)
-        if (PHP_OS_FAMILY !== 'Windows') {
-            system('clear');
-        }
     }
 }

--- a/app/Commands/PulseCommand.php
+++ b/app/Commands/PulseCommand.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace App\Commands;
+
+use App\Commands\Concerns\RendersPlayback;
+use App\Commands\Concerns\RequiresSpotifyConfig;
+use App\Services\SpotifyPlayerService;
+use Carbon\CarbonInterface;
+use LaravelZero\Framework\Commands\Command;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\warning;
+
+class PulseCommand extends Command
+{
+    use RendersPlayback;
+    use RequiresSpotifyConfig;
+
+    protected $signature = 'pulse
+        {--interval=15 : Seconds between heartbeats (minimum 5)}
+        {--json : Emit one heartbeat JSON object per tick instead of the board}
+        {--reset-at=04:00 : Local HH:MM at which the TODAY counters roll over}
+        {--max-ticks=0 : Stop after N ticks (0 = forever); for tests}';
+
+    protected $description = '💓 Live listening vitals — steady heartbeat for observability';
+
+    // --- in-memory "today" accumulators ---
+    private int $listenSeconds = 0;
+
+    private int $tracksPlayed = 0;
+
+    private int $skips = 0;
+
+    /** @var array<string, int> track name => play count */
+    private array $trackPlays = [];
+
+    /** @var array<string, int> artist name => play count */
+    private array $artistPlays = [];
+
+    /** @var list<int> recent activity samples (0-100) for the sparkline */
+    private array $sparkline = [];
+
+    // --- last-seen track fingerprint (for change/skip detection) ---
+    private ?string $lastUri = null;
+
+    private int $lastProgressMs = 0;
+
+    private int $lastDurationMs = 0;
+
+    private ?CarbonInterface $nextResetAt = null;
+
+    public function handle(SpotifyPlayerService $player): int
+    {
+        if (! $this->ensureConfigured()) {
+            return self::FAILURE;
+        }
+
+        $interval = max(5, (int) $this->option('interval'));
+        $jsonMode = (bool) $this->option('json');
+        $maxTicks = max(0, (int) $this->option('max-ticks'));
+
+        // Establish the first rollover boundary.
+        $this->maybeReset();
+
+        if (! $jsonMode) {
+            info('💓 Pulse — live listening vitals');
+            info("⏱️  Heartbeat every {$interval}s — Ctrl+C to stop");
+        }
+
+        if (function_exists('pcntl_signal')) {
+            pcntl_signal(SIGINT, function () use ($jsonMode): void {
+                if (! $jsonMode) {
+                    $this->newLine();
+                    info('👋 Pulse stopped.');
+                }
+                exit(0);
+            });
+        }
+
+        $tick = 0;
+
+        while (true) {
+            try {
+                $this->maybeReset();
+
+                $current = $player->getCurrentPlayback();
+                $this->accumulate($current);
+
+                if ($jsonMode) {
+                    $this->line((string) json_encode($this->heartbeat($current)));
+                } else {
+                    $this->renderBoard($current);
+                }
+            } catch (\Throwable $e) {
+                // auto_restart safety: a tick must never throw out of the loop,
+                // or the supervisor would crash-loop. Keep the pane alive.
+                if ($jsonMode) {
+                    $this->line((string) json_encode($this->heartbeat(null)));
+                } else {
+                    warning("⚠️  Pulse error: {$e->getMessage()}");
+                }
+            }
+
+            $tick++;
+            if ($maxTicks > 0 && $tick >= $maxTicks) {
+                break;
+            }
+
+            if (function_exists('pcntl_signal_dispatch')) {
+                pcntl_signal_dispatch();
+            }
+
+            sleep($interval);
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Fold a single playback snapshot into the running "today" totals.
+     * No-playback (null) is a calm, first-class state — never an error.
+     */
+    private function accumulate(?array $current): void
+    {
+        $uri = $current['uri'] ?? null;
+        $playing = (bool) ($current['is_playing'] ?? false);
+        $progress = (int) ($current['progress_ms'] ?? 0);
+        $duration = (int) ($current['duration_ms'] ?? 0);
+
+        if ($uri !== null && $uri !== $this->lastUri) {
+            // A new track started. If the previous one was abandoned well before
+            // its end, count it as a skip.
+            if ($this->lastUri !== null
+                && $this->lastDurationMs > 0
+                && $this->lastProgressMs < (int) ($this->lastDurationMs * 0.9)) {
+                $this->skips++;
+            }
+
+            $this->tracksPlayed++;
+            $name = (string) ($current['name'] ?? 'Unknown');
+            $artist = (string) ($current['artist'] ?? 'Unknown');
+            $this->trackPlays[$name] = ($this->trackPlays[$name] ?? 0) + 1;
+            $this->artistPlays[$artist] = ($this->artistPlays[$artist] ?? 0) + 1;
+        } elseif ($uri !== null && $uri === $this->lastUri && $playing && $progress > $this->lastProgressMs) {
+            // Same track advancing → accrue the elapsed listen time truthfully.
+            $this->listenSeconds += (int) round(($progress - $this->lastProgressMs) / 1000);
+        }
+
+        // Activity sparkline proxy (no audio-features API is exposed by the
+        // player service, so we sample volume while playing, 0 while idle).
+        $this->sparkline[] = $playing ? (int) ($current['device']['volume_percent'] ?? 50) : 0;
+        if (count($this->sparkline) > 40) {
+            array_shift($this->sparkline);
+        }
+
+        $this->lastUri = $uri;
+        $this->lastProgressMs = $progress;
+        $this->lastDurationMs = $duration;
+    }
+
+    /**
+     * The exact --json heartbeat schema (scratchpad #49, section A).
+     *
+     * @return array<string, mixed>
+     */
+    private function heartbeat(?array $current): array
+    {
+        return [
+            'type' => 'pulse',
+            'ts' => now()->toIso8601String(),
+            'is_playing' => (bool) ($current['is_playing'] ?? false),
+            'track' => $current['name'] ?? null,
+            'artist' => $current['artist'] ?? null,
+            'uri' => $current['uri'] ?? null,
+            'progress_ms' => (int) ($current['progress_ms'] ?? 0),
+            'duration_ms' => (int) ($current['duration_ms'] ?? 0),
+            'device' => $current['device']['name'] ?? null,
+            'volume' => isset($current['device']['volume_percent'])
+                ? (int) $current['device']['volume_percent']
+                : null,
+            'today' => [
+                'listen_seconds' => $this->listenSeconds,
+                'tracks_played' => $this->tracksPlayed,
+                'skips' => $this->skips,
+                'top_track' => $this->topKey($this->trackPlays),
+                'top_artist' => $this->topKey($this->artistPlays),
+            ],
+        ];
+    }
+
+    private function renderBoard(?array $current): void
+    {
+        $this->clearScreen();
+        $this->newLine();
+        $this->line('💓 <fg=magenta>PULSE</> — live listening vitals');
+        $this->line(str_repeat('─', 53));
+
+        if (! $current) {
+            $this->line('⏸️  <fg=gray>NOW</>   Nothing playing — standing by');
+        } else {
+            $name = (string) ($current['name'] ?? 'Unknown');
+            $artist = (string) ($current['artist'] ?? 'Unknown');
+            $this->line("🎵 <fg=cyan>NOW</>   {$name} — {$artist}");
+            $this->line('      '.$this->formatProgress(
+                (int) ($current['progress_ms'] ?? 0),
+                (int) ($current['duration_ms'] ?? 0)
+            ));
+
+            if (isset($current['device']['volume_percent'])) {
+                $this->line('      '.$this->formatVolume((int) $current['device']['volume_percent']));
+            }
+
+            $modes = $this->formatPlaybackModes(
+                (bool) ($current['shuffle_state'] ?? false),
+                (string) ($current['repeat_state'] ?? 'off')
+            );
+            if ($modes !== '') {
+                $this->line('      '.$modes);
+            }
+        }
+
+        $this->newLine();
+        $this->line(sprintf(
+            '📊 <fg=yellow>TODAY</> %s listened · %d plays · %d skips',
+            $this->humanizeSeconds($this->listenSeconds),
+            $this->tracksPlayed,
+            $this->skips
+        ));
+        $this->line(sprintf(
+            '🏆 <fg=green>TOP</>   %s — %s',
+            $this->topKey($this->trackPlays) ?? '—',
+            $this->topKey($this->artistPlays) ?? '—'
+        ));
+        $this->line('📈 '.$this->renderSparkline());
+        $this->newLine();
+    }
+
+    /**
+     * Roll the TODAY counters over once the configured reset time passes.
+     */
+    private function maybeReset(): void
+    {
+        if ($this->nextResetAt === null) {
+            $this->nextResetAt = $this->computeNextReset();
+
+            return;
+        }
+
+        if (now()->greaterThanOrEqualTo($this->nextResetAt)) {
+            $this->listenSeconds = 0;
+            $this->tracksPlayed = 0;
+            $this->skips = 0;
+            $this->trackPlays = [];
+            $this->artistPlays = [];
+
+            while (now()->greaterThanOrEqualTo($this->nextResetAt)) {
+                $this->nextResetAt = $this->nextResetAt->copy()->addDay();
+            }
+        }
+    }
+
+    private function computeNextReset(): CarbonInterface
+    {
+        [$hour, $minute] = array_pad(explode(':', (string) $this->option('reset-at')), 2, '0');
+
+        $candidate = now()->setTime((int) $hour, (int) $minute, 0);
+        if (now()->greaterThanOrEqualTo($candidate)) {
+            $candidate = $candidate->addDay();
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * @param  array<string, int>  $counts
+     */
+    private function topKey(array $counts): ?string
+    {
+        if ($counts === []) {
+            return null;
+        }
+
+        arsort($counts);
+
+        return (string) array_key_first($counts);
+    }
+
+    private function humanizeSeconds(int $seconds): string
+    {
+        $hours = intdiv($seconds, 3600);
+        $minutes = intdiv($seconds % 3600, 60);
+        $secs = $seconds % 60;
+
+        if ($hours > 0) {
+            return sprintf('%dh %dm', $hours, $minutes);
+        }
+
+        if ($minutes > 0) {
+            return sprintf('%dm %ds', $minutes, $secs);
+        }
+
+        return sprintf('%ds', $secs);
+    }
+
+    private function renderSparkline(): string
+    {
+        if ($this->sparkline === []) {
+            return '—';
+        }
+
+        $blocks = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+        $out = '';
+        foreach ($this->sparkline as $value) {
+            $clamped = max(0, min(100, $value));
+            $idx = (int) floor($clamped / 100 * (count($blocks) - 1));
+            $out .= $blocks[$idx];
+        }
+
+        return $out;
+    }
+}

--- a/app/Services/SessionService.php
+++ b/app/Services/SessionService.php
@@ -18,7 +18,6 @@ class SessionService
         private CuratorAgent $curator,
     ) {}
 
-
     /**
      * Plan a session from natural language input using AI agents.
      */

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,28 @@
             ]
         }
     },
+    "scripts": {
+        "test": "pest",
+        "test:coverage": "pest --coverage",
+        "lint": "pint --dirty",
+        "lint:check": "pint --test",
+        "analyse": "phpstan analyse --no-progress",
+        "refactor": "rector",
+        "refactor:check": "rector --dry-run",
+        "quality": [
+            "@lint",
+            "@analyse",
+            "@test"
+        ]
+    },
+    "scripts-descriptions": {
+        "test": "Run the Pest test suite",
+        "lint": "Format code with Laravel Pint",
+        "lint:check": "Check formatting without writing changes",
+        "analyse": "Run PHPStan static analysis",
+        "refactor": "Apply Rector refactorings",
+        "quality": "Run lint, static analysis, and tests in sequence"
+    },
     "minimum-stability": "stable",
     "prefer-stable": true,
     "bin": [

--- a/composer.lock
+++ b/composer.lock
@@ -714,25 +714,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c987f8ce84b8434fa430795eca0f3430663da72b",
+                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.11",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -741,8 +742,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.4",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -820,7 +822,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.0"
             },
             "funding": [
                 {
@@ -836,28 +838,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-02T12:40:51+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -903,7 +906,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -919,27 +922,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -947,8 +952,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1019,7 +1025,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -1035,20 +1041,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
                 "shasum": ""
             },
             "require": {
@@ -1057,7 +1063,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1105,7 +1111,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
             },
             "funding": [
                 {
@@ -1121,7 +1127,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-05-23T22:00:21+00:00"
         },
         {
             "name": "jolicode/jolinotif",
@@ -1482,16 +1488,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.51.0",
+            "version": "v12.61.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "ce4de3feb211e47c4f959d309ccf8a2733b1bc16"
+                "reference": "1124062a1ca92d290c8bcb9b7f649920fa6816bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/ce4de3feb211e47c4f959d309ccf8a2733b1bc16",
-                "reference": "ce4de3feb211e47c4f959d309ccf8a2733b1bc16",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/1124062a1ca92d290c8bcb9b7f649920fa6816bf",
+                "reference": "1124062a1ca92d290c8bcb9b7f649920fa6816bf",
                 "shasum": ""
             },
             "require": {
@@ -1512,7 +1518,7 @@
                 "guzzlehttp/uri-template": "^1.0",
                 "laravel/prompts": "^0.3.0",
                 "laravel/serializable-closure": "^1.3|^2.0",
-                "league/commonmark": "^2.7",
+                "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
@@ -1532,8 +1538,8 @@
                 "symfony/mailer": "^7.2.0",
                 "symfony/mime": "^7.2.0",
                 "symfony/polyfill-php83": "^1.33",
-                "symfony/polyfill-php84": "^1.33",
-                "symfony/polyfill-php85": "^1.33",
+                "symfony/polyfill-php84": "^1.34",
+                "symfony/polyfill-php85": "^1.34",
                 "symfony/process": "^7.2.0",
                 "symfony/routing": "^7.2.0",
                 "symfony/uid": "^7.2.0",
@@ -1607,7 +1613,7 @@
                 "orchestra/testbench-core": "^10.9.0",
                 "pda/pheanstalk": "^5.0.6|^7.0.0",
                 "php-http/discovery": "^1.15",
-                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan": "^2.1.41",
                 "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
                 "predis/predis": "^2.3|^3.0",
                 "resend/resend-php": "^0.10.0|^1.0",
@@ -1700,7 +1706,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-02-10T18:20:19+00:00"
+            "time": "2026-05-26T23:41:33+00:00"
         },
         {
             "name": "laravel/mcp",
@@ -1777,16 +1783,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.13",
+            "version": "v0.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "ed8c466571b37e977532fb2fd3c272c784d7050d"
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/ed8c466571b37e977532fb2fd3c272c784d7050d",
-                "reference": "ed8c466571b37e977532fb2fd3c272c784d7050d",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
                 "shasum": ""
             },
             "require": {
@@ -1830,22 +1836,22 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.13"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
             },
-            "time": "2026-02-06T12:17:10+00:00"
+            "time": "2026-05-19T00:47:18+00:00"
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.9",
+            "version": "v2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "8f631589ab07b7b52fead814965f5a800459cb3e"
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/8f631589ab07b7b52fead814965f5a800459cb3e",
-                "reference": "8f631589ab07b7b52fead814965f5a800459cb3e",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
                 "shasum": ""
             },
             "require": {
@@ -1893,7 +1899,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-02-03T06:55:34+00:00"
+            "time": "2026-04-16T14:03:50+00:00"
         },
         {
             "name": "league/commonmark",
@@ -2086,16 +2092,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.31.0",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "1717e0b3642b0df65ecb0cc89cdd99fa840672ff"
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/1717e0b3642b0df65ecb0cc89cdd99fa840672ff",
-                "reference": "1717e0b3642b0df65ecb0cc89cdd99fa840672ff",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
                 "shasum": ""
             },
             "require": {
@@ -2163,9 +2169,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.31.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
             },
-            "time": "2026-01-23T15:38:47+00:00"
+            "time": "2026-05-14T10:28:08+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -2274,20 +2280,20 @@
         },
         {
             "name": "league/uri",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/4436c6ec8d458e4244448b069cc572d088230b76",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.8",
+                "league/uri-interfaces": "^7.8.1",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -2360,7 +2366,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -2368,20 +2374,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-14T17:24:56+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
@@ -2444,7 +2450,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -2452,7 +2458,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-15T06:54:53+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2559,16 +2565,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.1",
+            "version": "3.11.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "f438fcc98f92babee98381d399c65336f3a3827f"
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/f438fcc98f92babee98381d399c65336f3a3827f",
-                "reference": "f438fcc98f92babee98381d399c65336f3a3827f",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
                 "shasum": ""
             },
             "require": {
@@ -2660,7 +2666,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-29T09:26:29+00:00"
+            "time": "2026-04-07T09:57:54+00:00"
         },
         {
             "name": "nette/schema",
@@ -2731,16 +2737,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -2816,9 +2822,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -3115,31 +3121,31 @@
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v2.3.3",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017"
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/6fb2a640ff502caace8e05fd7be3b503a7e1c017",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/712a31b768f5daea284c2169a7d227031001b9a8",
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^8.2",
-                "symfony/console": "^7.3.6"
+                "symfony/console": "^7.4.4 || ^8.0.4"
             },
             "require-dev": {
-                "illuminate/console": "^11.46.1",
-                "laravel/pint": "^1.25.1",
+                "illuminate/console": "^11.47.0",
+                "laravel/pint": "^1.27.1",
                 "mockery/mockery": "^1.6.12",
-                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.1.3",
+                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.3.2",
                 "phpstan/phpstan": "^1.12.32",
                 "phpstan/phpstan-strict-rules": "^1.6.2",
-                "symfony/var-dumper": "^7.3.5",
+                "symfony/var-dumper": "^7.3.5 || ^8.0.4",
                 "thecodingmachine/phpstan-strict-rules": "^1.0.0"
             },
             "type": "library",
@@ -3171,7 +3177,7 @@
                     "email": "enunomaduro@gmail.com"
                 }
             ],
-            "description": "Its like Tailwind CSS, but for the console.",
+            "description": "It's like Tailwind CSS, but for the console.",
             "keywords": [
                 "cli",
                 "console",
@@ -3182,7 +3188,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v2.3.3"
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -3198,7 +3204,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-20T02:34:59+00:00"
+            "time": "2026-02-16T23:10:27+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -4047,20 +4053,20 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v8.0.0",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "832119f9b8dbc6c8e6f65f30c5969eca1e88764f"
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/832119f9b8dbc6c8e6f65f30c5969eca1e88764f",
-                "reference": "832119f9b8dbc6c8e6f65f30c5969eca1e88764f",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "psr/clock": "^1.0"
             },
             "provide": {
@@ -4100,7 +4106,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v8.0.0"
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4120,20 +4126,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:46:48+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.4",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
-                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -4198,7 +4204,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.4"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4218,24 +4224,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-13T11:36:38+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v8.0.0",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "6225bd458c53ecdee056214cb4a2ffaf58bd592b"
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/6225bd458c53ecdee056214cb4a2ffaf58bd592b",
-                "reference": "6225bd458c53ecdee056214cb4a2ffaf58bd592b",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -4267,7 +4273,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.0.0"
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4287,20 +4293,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-30T14:17:19+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -4313,7 +4319,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -4338,7 +4344,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -4350,24 +4356,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8"
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8da531f364ddfee53e36092a7eebbbd0b775f6b8",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
                 "shasum": ""
             },
             "require": {
@@ -4416,7 +4426,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.4"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4436,20 +4446,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-20T16:42:42+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.4",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746"
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/dc2c0eba1af673e736bb851d747d266108aea746",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
                 "shasum": ""
             },
             "require": {
@@ -4501,7 +4511,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.4"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -4521,20 +4531,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T11:45:34+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -4548,7 +4558,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -4581,7 +4591,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -4593,24 +4603,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.5",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ad4daa7c38668dcb031e63bc99ea9bd42196a2cb"
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ad4daa7c38668dcb031e63bc99ea9bd42196a2cb",
-                "reference": "ad4daa7c38668dcb031e63bc99ea9bd42196a2cb",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
                 "shasum": ""
             },
             "require": {
@@ -4645,7 +4659,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.5"
+                "source": "https://github.com/symfony/finder/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4665,20 +4679,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "446d0db2b1f21575f1284b74533e425096abdfb6"
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/446d0db2b1f21575f1284b74533e425096abdfb6",
-                "reference": "446d0db2b1f21575f1284b74533e425096abdfb6",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
                 "shasum": ""
             },
             "require": {
@@ -4727,7 +4741,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.5"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4747,20 +4761,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T16:16:02+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "229eda477017f92bd2ce7615d06222ec0c19e82a"
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/229eda477017f92bd2ce7615d06222ec0c19e82a",
-                "reference": "229eda477017f92bd2ce7615d06222ec0c19e82a",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
                 "shasum": ""
             },
             "require": {
@@ -4802,7 +4816,7 @@
                 "symfony/config": "^6.4|^7.0|^8.0",
                 "symfony/console": "^6.4|^7.0|^8.0",
                 "symfony/css-selector": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
                 "symfony/dom-crawler": "^6.4|^7.0|^8.0",
                 "symfony/expression-language": "^6.4|^7.0|^8.0",
                 "symfony/finder": "^6.4|^7.0|^8.0",
@@ -4846,7 +4860,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.5"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4866,20 +4880,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-28T10:33:42+00:00"
+            "time": "2026-05-27T08:31:43+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.4",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "7b750074c40c694ceb34cb926d6dffee231c5cd6"
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/7b750074c40c694ceb34cb926d6dffee231c5cd6",
-                "reference": "7b750074c40c694ceb34cb926d6dffee231c5cd6",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/5cefb712a25f320579615ba9e1942abaeade7dff",
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff",
                 "shasum": ""
             },
             "require": {
@@ -4930,7 +4944,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.4"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -4950,20 +4964,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-08T08:25:11+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "b18c7e6e9eee1e19958138df10412f3c4c316148"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/b18c7e6e9eee1e19958138df10412f3c4c316148",
-                "reference": "b18c7e6e9eee1e19958138df10412f3c4c316148",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
@@ -4974,7 +4988,7 @@
             },
             "conflict": {
                 "egulias/email-validator": "~3.0.0",
-                "phpdocumentor/reflection-docblock": "<5.2|>=6",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
                 "phpdocumentor/type-resolver": "<1.5.1",
                 "symfony/mailer": "<6.4",
                 "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
@@ -4982,7 +4996,7 @@
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
-                "phpdocumentor/reflection-docblock": "^5.2",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
                 "symfony/dependency-injection": "^6.4|^7.0|^8.0",
                 "symfony/process": "^6.4|^7.0|^8.0",
                 "symfony/property-access": "^6.4|^7.0|^8.0",
@@ -5019,7 +5033,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.5"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5039,20 +5053,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T08:59:58+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -5102,7 +5116,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5122,20 +5136,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -5184,7 +5198,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5204,20 +5218,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -5271,7 +5285,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5291,20 +5305,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -5356,7 +5370,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -5376,20 +5390,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -5441,7 +5455,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5461,20 +5475,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -5525,7 +5539,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5545,20 +5559,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "8339098cae28673c15cce00d80734af0453054e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
+                "reference": "8339098cae28673c15cce00d80734af0453054e2",
                 "shasum": ""
             },
             "require": {
@@ -5605,7 +5619,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5625,20 +5639,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -5685,7 +5699,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5705,20 +5719,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -5765,7 +5779,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5785,20 +5799,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-23T16:12:55+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -5848,7 +5862,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5868,20 +5882,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -5913,7 +5927,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.5"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5933,20 +5947,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.4",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "0798827fe2c79caeed41d70b680c2c3507d10147"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/0798827fe2c79caeed41d70b680c2c3507d10147",
-                "reference": "0798827fe2c79caeed41d70b680c2c3507d10147",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -5998,7 +6012,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.4"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6018,20 +6032,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-12T12:19:02+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -6049,7 +6063,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6085,7 +6099,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -6105,24 +6119,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.4",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "758b372d6882506821ed666032e43020c4f57194"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/758b372d6882506821ed666032e43020c4f57194",
-                "reference": "758b372d6882506821ed666032e43020c4f57194",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-intl-grapheme": "^1.33",
                 "symfony/polyfill-intl-normalizer": "^1.0",
@@ -6175,7 +6189,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.4"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -6195,24 +6209,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-12T12:37:40+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v8.0.4",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "db70c8ce7db74fd2da7b1d268db46b2a8ce32c10"
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/db70c8ce7db74fd2da7b1d268db46b2a8ce32c10",
-                "reference": "db70c8ce7db74fd2da7b1d268db46b2a8ce32c10",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-mbstring": "^1.0",
                 "symfony/translation-contracts": "^3.6.1"
             },
@@ -6268,7 +6282,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.0.4"
+                "source": "https://github.com/symfony/translation/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -6288,20 +6302,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-13T13:06:50+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
                 "shasum": ""
             },
             "require": {
@@ -6314,7 +6328,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6350,7 +6364,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -6370,20 +6384,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v7.4.4",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36"
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/7719ce8aba76be93dfe249192f1fbfa52c588e36",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/2676b524340abcfe4d6151ec698463cebafee439",
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439",
                 "shasum": ""
             },
             "require": {
@@ -6428,7 +6442,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.4.4"
+                "source": "https://github.com/symfony/uid/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -6448,20 +6462,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-03T23:30:35+00:00"
+            "time": "2026-04-30T15:19:22+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "0e4769b46a0c3c62390d124635ce59f66874b282"
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0e4769b46a0c3c62390d124635ce59f66874b282",
-                "reference": "0e4769b46a0c3c62390d124635ce59f66874b282",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
                 "shasum": ""
             },
             "require": {
@@ -6515,7 +6529,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.4"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -6535,7 +6549,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-01T22:13:48+00:00"
+            "time": "2026-03-30T13:44:50+00:00"
         },
         {
             "name": "the-shit/vector",
@@ -6749,23 +6763,23 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -6795,7 +6809,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
             },
             "funding": [
                 {
@@ -6819,7 +6833,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
+            "time": "2026-04-26T05:33:54+00:00"
         }
     ],
     "packages-dev": [
@@ -9860,16 +9874,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.3",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "6976757ba8dd70bf8cbaea0914ad84d8b51a9f46"
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6976757ba8dd70bf8cbaea0914ad84d8b51a9f46",
-                "reference": "6976757ba8dd70bf8cbaea0914ad84d8b51a9f46",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
                 "shasum": ""
             },
             "require": {
@@ -9885,7 +9899,11 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
+                    "dev-master": "2.0-dev",
                     "dev-feature/2-0": "2.0-dev"
                 }
             },
@@ -9916,9 +9934,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.3"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
             },
-            "time": "2026-02-13T21:01:40+00:00"
+            "time": "2026-05-20T13:07:01+00:00"
         }
     ],
     "aliases": [],

--- a/config/commands.php
+++ b/config/commands.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+| Dev/test commands that ship in the binary but are hidden from the command
+| list in the production distribution. "Production" = the built phar users
+| download (Phar::running() is only truthy inside a packaged phar); running
+| `php spotify ...` from source always shows everything. Set APP_ENV=production
+| to force the production surface while testing locally.
+*/
+$inDistribution = \Phar::running(false) !== '' || env('APP_ENV') === 'production';
+
+$devHidden = $inDistribution ? [
+    App\Commands\WebhookTestCommand::class,
+    App\Commands\ServeCommand::class,
+    App\Commands\EventEmitCommand::class,
+] : [];
+
 return [
 
     /*
@@ -68,6 +83,7 @@ return [
         Laravel\Mcp\Console\Commands\MakePromptCommand::class,
         Laravel\Mcp\Console\Commands\MakeResourceCommand::class,
         Laravel\Mcp\Console\Commands\InspectorCommand::class,
+        ...$devHidden,
     ],
 
     /*

--- a/solo.yml
+++ b/solo.yml
@@ -1,0 +1,63 @@
+name: music
+icon: null
+icon_initials: 🎵
+processes:
+  🌐 Vibes Page:
+    command: php -S 127.0.0.1:8000 -t docs
+    working_dir: null
+    auto_start: true
+    auto_restart: true
+    restart_when_changed: []
+    env: {}
+  🧪 Tests:
+    command: composer test
+    working_dir: null
+    auto_start: false
+    auto_restart: false
+    restart_when_changed: []
+    env: {}
+  🔌 Request Server:
+    command: php spotify serve --port=9876
+    working_dir: null
+    auto_start: false
+    auto_restart: true
+    restart_when_changed: []
+    env: {}
+  📡 Now Playing:
+    command: php spotify watch --json --interval=5
+    working_dir: null
+    auto_start: true
+    auto_restart: true
+    restart_when_changed:
+    - app/Commands/WatchCommand.php
+    - app/Services/SpotifyPlayerService.php
+    env: {}
+  ✨ Quality:
+    command: composer quality
+    working_dir: null
+    auto_start: false
+    auto_restart: false
+    restart_when_changed: []
+    env: {}
+  🎵 Player:
+    command: php spotify player
+    working_dir: null
+    auto_start: true
+    auto_restart: false
+    restart_when_changed:
+    - app/Commands/PlayerCommand.php
+    env: {}
+  🟢 Daemon:
+    command: sh -c 'php spotify daemon start; while true; do php spotify daemon health --heal --json; sleep 30; done'
+    working_dir: null
+    auto_start: true
+    auto_restart: true
+    restart_when_changed: []
+    env: {}
+  💗 Pulse:
+    command: ./spotify pulse
+    working_dir: null
+    auto_start: true
+    auto_restart: true
+    restart_when_changed: []
+    env: {}

--- a/tests/Feature/FindCommandTest.php
+++ b/tests/Feature/FindCommandTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use App\Services\SpotifyAuthManager;
+use App\Services\SpotifyDiscoveryService;
+use App\Services\SpotifyPlayerService;
+
+describe('FindCommand', function (): void {
+
+    // Laravel Prompts only engages its test fallbacks (which power expectsSearch /
+    // expectsConfirmation) when the app reports the "testing" environment. Laravel
+    // Zero doesn't set that by default, so opt in here. The app is rebuilt per test,
+    // so this stays local to FindCommand.
+    // Laravel Prompts only engages its test fallbacks (which power expectsSearch /
+    // expectsConfirmation) when the app reports the "testing" environment, and
+    // Laravel Zero doesn't set that by default. Laravel Zero also reuses the
+    // application instance across tests, so capture and restore the env (and the
+    // global Prompt statics it flips on) to avoid leaking into later test files.
+    beforeEach(function (): void {
+        $this->originalEnv = $this->app['env'];
+        $this->app['env'] = 'testing';
+    });
+
+    afterEach(function (): void {
+        $this->app['env'] = $this->originalEnv;
+        \Laravel\Prompts\Prompt::interactive(false);
+
+        // Prompt::fallbackWhen() is a latch (`$condition || $shouldFallback`) with no
+        // public way back to false, so reset the shared static directly. Otherwise
+        // the fallback stays enabled process-wide and breaks later prompt tests.
+        $fallback = new ReflectionProperty(\Laravel\Prompts\Prompt::class, 'shouldFallback');
+        $fallback->setValue(null, false);
+    });
+
+    $searchResults = [
+        [
+            'uri' => 'spotify:track:123',
+            'name' => 'Test Song',
+            'artist' => 'Test Artist',
+            'album' => 'Test Album',
+        ],
+    ];
+
+    $expectedOptions = [
+        'spotify:track:123' => '🎵 Test Song — Test Artist (Test Album)',
+    ];
+
+    it('searches and plays the picked track', function () use ($searchResults, $expectedOptions): void {
+        $this->mock(SpotifyAuthManager::class, function ($mock): void {
+            $mock->shouldReceive('isConfigured')->once()->andReturn(true);
+        });
+        $this->mock(SpotifyDiscoveryService::class, function ($mock) use ($searchResults): void {
+            $mock->shouldReceive('searchMultiple')
+                ->once()
+                ->with('test song', 'track', 12)
+                ->andReturn($searchResults);
+        });
+        $this->mock(SpotifyPlayerService::class, function ($mock): void {
+            $mock->shouldReceive('play')->once()->with('spotify:track:123');
+            $mock->shouldNotReceive('addToQueue');
+        });
+
+        $this->artisan('find')
+            ->expectsSearch('🔎 Search Spotify', 'spotify:track:123', 'test song', $expectedOptions)
+            ->expectsConfirmation('Add to queue instead of playing now?', 'no')
+            ->expectsQuestion('Press enter to continue...', '')
+            ->expectsConfirmation('Search for another?', 'no')
+            ->expectsOutputToContain('▶️  Playing: spotify:track:123')
+            ->assertExitCode(0);
+    });
+
+    it('searches and queues the picked track when confirmed', function () use ($searchResults, $expectedOptions): void {
+        $this->mock(SpotifyAuthManager::class, function ($mock): void {
+            $mock->shouldReceive('isConfigured')->once()->andReturn(true);
+        });
+        $this->mock(SpotifyDiscoveryService::class, function ($mock) use ($searchResults): void {
+            $mock->shouldReceive('searchMultiple')
+                ->once()
+                ->with('test song', 'track', 12)
+                ->andReturn($searchResults);
+        });
+        $this->mock(SpotifyPlayerService::class, function ($mock): void {
+            $mock->shouldReceive('addToQueue')->once()->with('spotify:track:123');
+            $mock->shouldNotReceive('play');
+        });
+
+        $this->artisan('find')
+            ->expectsSearch('🔎 Search Spotify', 'spotify:track:123', 'test song', $expectedOptions)
+            ->expectsConfirmation('Add to queue instead of playing now?', 'yes')
+            ->expectsQuestion('Press enter to continue...', '')
+            ->expectsConfirmation('Search for another?', 'no')
+            ->expectsOutputToContain('➕ Added to queue: spotify:track:123')
+            ->assertExitCode(0);
+    });
+
+    it('queues directly with the --queue flag without asking', function () use ($searchResults, $expectedOptions): void {
+        $this->mock(SpotifyAuthManager::class, function ($mock): void {
+            $mock->shouldReceive('isConfigured')->once()->andReturn(true);
+        });
+        $this->mock(SpotifyDiscoveryService::class, function ($mock) use ($searchResults): void {
+            $mock->shouldReceive('searchMultiple')
+                ->once()
+                ->with('test song', 'track', 12)
+                ->andReturn($searchResults);
+        });
+        $this->mock(SpotifyPlayerService::class, function ($mock): void {
+            $mock->shouldReceive('addToQueue')->once()->with('spotify:track:123');
+            $mock->shouldNotReceive('play');
+        });
+
+        $this->artisan('find', ['--queue' => true])
+            ->expectsSearch('🔎 Search Spotify', 'spotify:track:123', 'test song', $expectedOptions)
+            ->expectsQuestion('Press enter to continue...', '')
+            ->expectsConfirmation('Search for another?', 'no')
+            ->expectsOutputToContain('➕ Added to queue: spotify:track:123')
+            ->assertExitCode(0);
+    });
+
+    it('hints at "spotify devices" when playback has no device', function () use ($searchResults, $expectedOptions): void {
+        $this->mock(SpotifyAuthManager::class, function ($mock): void {
+            $mock->shouldReceive('isConfigured')->once()->andReturn(true);
+        });
+        $this->mock(SpotifyDiscoveryService::class, function ($mock) use ($searchResults): void {
+            $mock->shouldReceive('searchMultiple')
+                ->once()
+                ->andReturn($searchResults);
+        });
+        $this->mock(SpotifyPlayerService::class, function ($mock): void {
+            $mock->shouldReceive('play')
+                ->once()
+                ->with('spotify:track:123')
+                ->andThrow(new Exception('No Spotify devices available. Open Spotify on any device.'));
+        });
+
+        $this->artisan('find')
+            ->expectsSearch('🔎 Search Spotify', 'spotify:track:123', 'test song', $expectedOptions)
+            ->expectsConfirmation('Add to queue instead of playing now?', 'no')
+            ->expectsQuestion('Press enter to continue...', '')
+            ->expectsConfirmation('Search for another?', 'no')
+            ->expectsOutputToContain('No active Spotify device found.')
+            ->expectsOutputToContain('spotify devices')
+            ->assertExitCode(0);
+    });
+
+    it('requires configuration', function (): void {
+        $this->mock(SpotifyAuthManager::class, function ($mock): void {
+            $mock->shouldReceive('isConfigured')->once()->andReturn(false);
+        });
+
+        $this->artisan('find')
+            ->expectsOutputToContain('Spotify is not configured')
+            ->assertExitCode(1);
+    });
+
+});

--- a/tests/Feature/PulseCommandTest.php
+++ b/tests/Feature/PulseCommandTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Services\SpotifyAuthManager;
+use App\Services\SpotifyPlayerService;
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * Run one pulse heartbeat in --json mode and return the decoded object.
+ *
+ * pulse never prompts in --json mode, so we drive the otherwise-infinite loop
+ * with --max-ticks=1 (a test-only guard documented in the signature). We assert
+ * the decoded heartbeat rather than chaining many expectsOutputToContain calls:
+ * the whole heartbeat is a single write, and Laravel routes each substring
+ * matcher to only one write, so only one substring assertion can ever match.
+ */
+function pulseHeartbeat(): array
+{
+    $code = Artisan::call('pulse', ['--json' => true, '--max-ticks' => 1]);
+    expect($code)->toBe(0);
+
+    $line = collect(explode("\n", trim(Artisan::output())))
+        ->map(fn (string $l): string => trim($l))
+        ->first(fn (string $l): bool => str_starts_with($l, '{'));
+
+    expect($line)->not->toBeNull();
+
+    return json_decode((string) $line, true, flags: JSON_THROW_ON_ERROR);
+}
+
+describe('PulseCommand', function (): void {
+
+    it('emits a single JSON heartbeat for the current playback', function (): void {
+        $this->mock(SpotifyAuthManager::class, function ($mock): void {
+            $mock->shouldReceive('isConfigured')->once()->andReturn(true);
+        });
+        $this->mock(SpotifyPlayerService::class, function ($mock): void {
+            $mock->shouldReceive('getCurrentPlayback')->once()->andReturn([
+                'uri' => 'spotify:track:abc',
+                'name' => 'Test Song',
+                'artist' => 'Test Artist',
+                'album' => 'Test Album',
+                'progress_ms' => 30000,
+                'duration_ms' => 180000,
+                'is_playing' => true,
+                'shuffle_state' => false,
+                'repeat_state' => 'off',
+                'device' => ['name' => 'Living Room', 'volume_percent' => 55],
+            ]);
+        });
+
+        $beat = pulseHeartbeat();
+
+        // Exact schema from scratchpad #49 section A.
+        expect($beat)->toHaveKeys([
+            'type', 'ts', 'is_playing', 'track', 'artist', 'uri',
+            'progress_ms', 'duration_ms', 'device', 'volume', 'today',
+        ]);
+        expect($beat['type'])->toBe('pulse');
+        expect($beat['is_playing'])->toBeTrue();
+        expect($beat['track'])->toBe('Test Song');
+        expect($beat['artist'])->toBe('Test Artist');
+        expect($beat['uri'])->toBe('spotify:track:abc');
+        expect($beat['progress_ms'])->toBe(30000);
+        expect($beat['duration_ms'])->toBe(180000);
+        expect($beat['device'])->toBe('Living Room');
+        expect($beat['volume'])->toBe(55);
+
+        expect($beat['today'])->toHaveKeys([
+            'listen_seconds', 'tracks_played', 'skips', 'top_track', 'top_artist',
+        ]);
+        // First track seen counts as one play; top_* resolve to it.
+        expect($beat['today']['tracks_played'])->toBe(1);
+        expect($beat['today']['skips'])->toBe(0);
+        expect($beat['today']['top_track'])->toBe('Test Song');
+        expect($beat['today']['top_artist'])->toBe('Test Artist');
+    });
+
+    it('emits a heartbeat even when nothing is playing so the pane never goes silent', function (): void {
+        $this->mock(SpotifyAuthManager::class, function ($mock): void {
+            $mock->shouldReceive('isConfigured')->once()->andReturn(true);
+        });
+        $this->mock(SpotifyPlayerService::class, function ($mock): void {
+            $mock->shouldReceive('getCurrentPlayback')->once()->andReturn(null);
+        });
+
+        $beat = pulseHeartbeat();
+
+        expect($beat['type'])->toBe('pulse');
+        expect($beat['is_playing'])->toBeFalse();
+        expect($beat['track'])->toBeNull();
+        expect($beat['artist'])->toBeNull();
+        expect($beat['uri'])->toBeNull();
+        expect($beat['progress_ms'])->toBe(0);
+        expect($beat['duration_ms'])->toBe(0);
+        expect($beat['device'])->toBeNull();
+        expect($beat['volume'])->toBeNull();
+        expect($beat['today']['tracks_played'])->toBe(0);
+        expect($beat['today']['top_track'])->toBeNull();
+        expect($beat['today']['top_artist'])->toBeNull();
+    });
+
+    it('stays alive with an idle heartbeat when the player throws', function (): void {
+        $this->mock(SpotifyAuthManager::class, function ($mock): void {
+            $mock->shouldReceive('isConfigured')->once()->andReturn(true);
+        });
+        $this->mock(SpotifyPlayerService::class, function ($mock): void {
+            $mock->shouldReceive('getCurrentPlayback')
+                ->once()
+                ->andThrow(new Exception('Spotify API exploded'));
+        });
+
+        $beat = pulseHeartbeat();
+
+        // A failing tick must never crash the loop (auto_restart safety); it
+        // degrades to a schema-valid idle heartbeat.
+        expect($beat['type'])->toBe('pulse');
+        expect($beat['is_playing'])->toBeFalse();
+        expect($beat['track'])->toBeNull();
+    });
+
+    it('requires configuration', function (): void {
+        $this->mock(SpotifyAuthManager::class, function ($mock): void {
+            $mock->shouldReceive('isConfigured')->once()->andReturn(false);
+        });
+
+        $this->artisan('pulse', ['--json' => true, '--max-ticks' => 1])
+            ->expectsOutputToContain('Spotify is not configured')
+            ->assertExitCode(1);
+    });
+
+});


### PR DESCRIPTION
## Summary

Developer-experience and CLI-surface improvements, landed as atomic commits.

### New commands
- **`find`** — fuzzy typeahead search-and-play (live `search()` → play/queue), with a loop and graceful no-device handling.
- **`pulse`** — live listening "vitals" board with a `--json` heartbeat stream (observability-friendly; free-flow layout so it's immune to emoji-width issues).

### Player UI
- Extracted shared render helpers into a `RendersPlayback` trait (reused by `pulse`).
- **Fixed now-playing box alignment** — emoji are 2 columns but the old `sprintf('%-Ns')` padded by bytes, so right borders drifted. Padding now measures display width via `mb_strwidth` (`displayWidth()`/`padRight()`).
- Initial styling polish (colorized header, bolded track title).

### Production hygiene
- Hide dev/test commands (`webhook:test`, `serve`, `event:emit`) from the **built phar** via a `Phar::running()` gate — they stay fully usable when run from source.

### Tooling / DX
- Composer scripts: `test`, `lint` (`pint --dirty`), `analyse`, `refactor`, `quality`.
- `solo.yml` cockpit: a deliberate short/long-running process taxonomy with `watch --json` as the observability spine.

## Tests
`composer test` → **542 passed (1620 assertions)**. New Pest coverage for `find` (5) and `pulse` (4).