### PR TITLE
docs: README hook-first rewrite + launch copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-# Spotify CLI
+# Your codebase has a soundtrack
 
-Spotify as terminal infrastructure. 30+ commands, 12 MCP tools, mood-aware autopilot, event-driven integrations — use what you need, ignore what you don't.
+Every commit in this repo carries the Spotify track that was playing when the code was written. A git hook injects it. CI enforces it. **No music, no merge.**
 
-**[Docs](https://the-shit.github.io/music/)** · **[Commands](https://the-shit.github.io/music/commands.html)** · **[MCP](https://the-shit.github.io/music/mcp.html)** · **[Vibes](https://the-shit.github.io/music/vibes.html)**
+The byproduct is the [vibes page](https://the-shit.github.io/music/vibes.html) — an auto-generated, living soundtrack of the entire codebase. Every song that was playing when every line was written, regenerated on every push to master.
+
+**[Docs](https://the-shit.github.io/music/)** · **[Vibes](https://the-shit.github.io/music/vibes.html)** · **[Commands](https://the-shit.github.io/music/commands.html)** · **[MCP](https://the-shit.github.io/music/mcp.html)**
+
+## How the soundtrack happens
+
+1. **You listen** — Spotify plays while you code, like it already does.
+2. **The hook captures** — a pre-commit hook asks the CLI what's playing and appends the track URL to your commit message.
+3. **CI enforces** — the Vibe Check gate scans every commit for a Spotify URL. No music, no merge.
+4. **The vibes page regenerates** — every push to master rebuilds the soundtrack of the whole repo.
+
+It's enforced by the same pipeline as PHPStan and test coverage. Music is a CI gate here, not a gimmick.
 
 ## Quick Start
 
@@ -15,16 +26,26 @@ spotify play "Killing In the Name"
 spotify current    # See what's playing
 ```
 
-That's it. Everything else is optional.
+That's it. The hook and CI gate are wired up per-repo — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Use What You Need
+## The Premium Player
 
-Every feature is a layer you opt into. Nothing assumes anything else is running.
+`spotify player:premium` — a full php-tui player in your terminal. Album art rendered as ANSI, mood-aware theming, a search palette with play-now and queue actions, playlist browsing, and a queue peek. It's the player a vibes-enforced codebase deserves.
+
+```bash
+spotify player:premium
+```
+
+(The classic `spotify player` TUI is still there if you want something lighter.)
+
+## And it's a full Spotify CLI
+
+The soundtrack is enforced, but the day-to-day tooling carries its weight too: 30+ commands, 12 MCP tools, mood-aware autopilot, event-driven integrations. Every feature is a layer you opt into — nothing assumes anything else is running.
 
 | Layer | What it does | Required? |
 |---|---|---|
 | **CLI commands** | Play, pause, skip, queue, search, volume, shuffle, repeat | Just this |
-| **Interactive player** | TUI with progress bar, controls, playlist browsing | `spotify player` when you want it |
+| **Premium player** | php-tui player with art, mood theming, search palette | `spotify player:premium` when you want it |
 | **MCP server** | 12 tools for AI assistants (Claude, etc.) to control Spotify | Configure if you use AI tools |
 | **Daemon** | Headless Spotify Connect speaker via spotifyd | Install if you want background playback |
 | **Media bridge** | macOS Control Center + media keys via native Swift | Install if you want media key control |
@@ -37,7 +58,7 @@ See the full [command reference](https://the-shit.github.io/music/commands.html)
 
 ## Why This Instead Of...
 
-**spotify_player / ncspot / spotatui** — Great TUI players. But they only play music. No MCP server, no queue intelligence, no integrations, no service management. If you just want a terminal UI, those are solid. If you want Spotify as composable infrastructure, this is it.
+**spotify_player / ncspot / spotatui** — Great TUI players. But they only play music. No commit soundtrack, no MCP server, no queue intelligence, no integrations. If you just want a terminal UI, those are solid. If you want Spotify as composable infrastructure — and your git history to have a soundtrack — this is it.
 
 **Standalone MCP servers** — There are a handful on Smithery/GitHub. Most are weekend scripts with 3-5 tools and no maintenance. This is a real application with 12 MCP tools, 2 resources, battle-tested against Spotify's API deprecations, and actively maintained.
 
@@ -114,12 +135,6 @@ spotify webhook:configure --url=https://your.endpoint/hook --secret=your-secret
 ```bash
 spotify watch --json | your-consumer
 ```
-
-## Vibe Check
-
-Every commit must include the Spotify track playing when the code was written. A pre-commit hook injects the track metadata, and CI rejects any push without one.
-
-The result is the [vibes page](https://the-shit.github.io/music/vibes.html) — a living soundtrack of the entire codebase.
 
 ## Contributing
 

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -1,0 +1,67 @@
+# Launch Copy
+
+Drafts for Show HN and Twitter/X, built around the hook: every commit carries the Spotify track playing when the code was written, CI rejects musicless commits, and the byproduct is an auto-generated soundtrack of the whole codebase.
+
+---
+
+## Show HN
+
+### Title
+
+> Show HN: My CI rejects commits unless they include the song I was listening to
+
+Alternates:
+
+> Show HN: Every commit in this repo carries the Spotify track playing when it was written
+>
+> Show HN: No music, no merge — a CI gate that gives your codebase a soundtrack
+
+### Body
+
+I built a Spotify CLI in PHP, and then it grew a rule: every commit must include the track that was playing when the code was written.
+
+How it works:
+
+- A pre-commit hook asks the CLI what's playing on Spotify and appends the track URL to the commit message.
+- A CI gate ("Vibe Check") scans every commit on every PR for a Spotify URL. No music, no merge. It sits next to PHPStan and test coverage — same pipeline, same blocking status.
+- On every push to master, a vibes page regenerates: an auto-generated soundtrack of the entire codebase. Every song that was playing when every line was written.
+
+Vibes page: https://the-shit.github.io/music/vibes.html
+Repo: https://github.com/the-shit/music
+
+It started as a joke and then turned out to be weirdly useful. The track on a commit is a timestamp for your mental state — I can tell which commits were 2am death-metal debugging and which were calm Sunday-morning refactors. It's `git blame` for mood.
+
+Under the joke there's a real tool: a Spotify CLI with 30+ commands (play/queue/search/devices), a php-tui terminal player with album art and a search palette (`spotify player:premium`), an MCP server with 12 tools so Claude can DJ while you work, mood-based queue autopilot, and launchd-managed services for headless playback on macOS. Laravel Zero, single binary, no Electron.
+
+Happy to answer questions about the hook mechanics, fighting Spotify's API deprecations (RIP audio-features endpoint), or building TUIs in PHP of all things.
+
+---
+
+## Tweet / Thread
+
+### Single tweet
+
+> My CI rejects commits unless they include the song I was listening to.
+>
+> A git hook grabs the current Spotify track, CI enforces it on every PR — no music, no merge — and the repo auto-generates a soundtrack of every line ever written.
+>
+> https://github.com/the-shit/music
+
+### Thread version
+
+**1/**
+My CI rejects commits unless they include the song I was listening to. Not a joke — it's a blocking gate next to PHPStan and test coverage. No music, no merge.
+
+**2/**
+The mechanics: a pre-commit hook asks my Spotify CLI what's playing and stamps the track URL into the commit message. CI scans every commit on every PR. Miss one and the build is red.
+
+**3/**
+The byproduct is the best part: a vibes page that regenerates on every push — an auto-generated soundtrack of the entire codebase. Every song that was playing when every line was written.
+https://the-shit.github.io/music/vibes.html
+
+**4/**
+It's `git blame` for mood. I can tell which commits were 2am death-metal debugging and which were calm Sunday-morning refactors.
+
+**5/**
+Under the joke: a full Spotify CLI — 30+ commands, a php-tui terminal player with album art (`spotify player:premium`), an MCP server so Claude can DJ while you code, mood-based queue autopilot. PHP, single binary, no Electron.
+https://github.com/the-shit/music


### PR DESCRIPTION
## Why

The README led with the generic framing — "Spotify CLI, 30+ commands" — which is the least differentiated thing about this repo. The actual hook is the soundtrack: every commit carries the Spotify track playing when the code was written, CI rejects musicless commits (**no music, no merge**), and the byproduct is the auto-generated [vibes page](https://the-shit.github.io/music/vibes.html).

PR #138 already gave the docs landing page this treatment. This PR does the same for the repo-facing README and adds launch copy.

## What

- **README.md** — rewritten to lead with the hook: new title ("Your codebase has a soundtrack"), a "How the soundtrack happens" section up top, a dedicated highlight for the premium php-tui player (`spotify player:premium`), and the CLI-layers table demoted to an "And it's a full Spotify CLI" section below the fold. All existing content (MCP, moods, services, integrations, contributing, requirements) preserved.
- **docs/launch.md** — new: Show HN title + body draft (with alternates) and a single tweet + thread draft, all built around the hook.

Docs/copy only — no code changes.