### PR TITLE
feat(player): native queue editor — search-from-queue + skip

### DIFF
--- a/app/Commands/PremiumPlayerCommand.php
+++ b/app/Commands/PremiumPlayerCommand.php
@@ -168,6 +168,7 @@ class PremiumPlayerCommand extends Command
             'status' => '',
             'dirty' => false,       // query changed since the last query → re-search
             'lastQueried' => 0.0,
+            'returnTo' => null,     // self::QUEUE when opened from the queue overlay
         ];
 
         // Interactive "up next" overlay state. Items are the raw Spotify queue tracks,
@@ -243,8 +244,28 @@ class PremiumPlayerCommand extends Command
                 while (($event = $events->next()) !== null) {
                     if ($search['active']) {
                         $outcome = $this->handleSearchEvent($event, $player, $search);
+
+                        // The palette can be LAYERED over the queue overlay (opened
+                        // with `/` from the queue — returnTo). When it closes (esc,
+                        // or a successful ⏎ play), drop back onto a FRESH queue
+                        // snapshot so a just-queued/just-played track shows, and
+                        // clamp the selection to the new length.
+                        if (! $search['active'] && $search['returnTo'] === self::QUEUE) {
+                            $queue['items'] = $this->safeQueue($player);
+                            $queue['selected'] = max(0, min($queue['selected'], count($queue['items']) - 1));
+                            $queue['status'] = '';
+                        }
                     } elseif ($queue['active']) {
                         $outcome = $this->handleQueueEvent($event, $player, $queue);
+
+                        // `/` from the queue layers the search palette ON TOP (the
+                        // queue state stays intact underneath); returnTo records
+                        // where to land when the palette closes.
+                        if ($outcome === self::SEARCH) {
+                            $search = ['active' => true, 'query' => '', 'results' => [], 'selected' => 0, 'status' => '', 'dirty' => false, 'lastQueried' => 0.0, 'returnTo' => self::QUEUE];
+
+                            continue;
+                        }
                     } elseif ($playlist['active']) {
                         $outcome = $this->handlePlaylistEvent($event, $player, $playlist);
                     } else {
@@ -252,7 +273,7 @@ class PremiumPlayerCommand extends Command
 
                         // `/` opens the palette in-place (no suspend).
                         if ($outcome === self::SEARCH) {
-                            $search = ['active' => true, 'query' => '', 'results' => [], 'selected' => 0, 'status' => '', 'dirty' => false, 'lastQueried' => 0.0];
+                            $search = ['active' => true, 'query' => '', 'results' => [], 'selected' => 0, 'status' => '', 'dirty' => false, 'lastQueried' => 0.0, 'returnTo' => null];
 
                             continue;
                         }
@@ -616,9 +637,12 @@ class PremiumPlayerCommand extends Command
 
     /**
      * Handle a keypress while the up-next queue overlay is open: ↑↓ move the
-     * highlighted row, ⏎ plays the chosen up-next track (and closes), esc closes,
-     * Ctrl+C still quits the whole player. A no-device/API failure on play keeps the
-     * overlay open with an inline status — same contract as the search palette.
+     * highlighted row, ⏎ plays the chosen up-next track (and closes), `/` layers
+     * the search palette over the queue (to add tracks in context — closing it
+     * returns to a refreshed queue), `n` skips the current track (the queue shifts,
+     * so it is re-snapshotted in place), esc closes, Ctrl+C still quits the whole
+     * player. A no-device/API failure on play/skip keeps the overlay open with an
+     * inline status — same contract as the search palette.
      *
      * @param  array<string, mixed>  $queue
      */
@@ -634,12 +658,42 @@ class PremiumPlayerCommand extends Command
             };
         }
 
-        // Ctrl+C always quits the whole player, even from an overlay.
-        if ($event instanceof CharKeyEvent && $event->char === "\x03") {
-            return self::QUIT;
+        if (! $event instanceof CharKeyEvent) {
+            return self::NONE;
         }
 
-        return self::NONE;
+        return match ($event->char) {
+            "\x03" => self::QUIT, // Ctrl+C always quits, even from an overlay
+            '/' => self::SEARCH,  // layer the search palette over the queue
+            'n' => $this->skipFromQueue($player, $queue),
+            default => self::NONE,
+        };
+    }
+
+    /**
+     * Skip the current track from the queue overlay and KEEP it open. The queue
+     * shifts when its head starts playing, so the snapshot is refreshed in place
+     * (selection clamped) rather than left stale. A no-device/API failure keeps
+     * the overlay open with an inline status — same contract as ⏎ play.
+     *
+     * @param  array<string, mixed>  $queue
+     */
+    private function skipFromQueue(SpotifyPlayerService $player, array &$queue): string
+    {
+        try {
+            $player->next();
+        } catch (Throwable) {
+            // Plain text, NO variation-selector emoji (same width trap as elsewhere).
+            $queue['status'] = 'No active device';
+
+            return self::NONE;
+        }
+
+        $queue['items'] = $this->safeQueue($player);
+        $queue['selected'] = max(0, min($queue['selected'], count($queue['items']) - 1));
+        $queue['status'] = '';
+
+        return self::REFRESH; // refetch now-playing so the panel reflects the skip
     }
 
     /**

--- a/app/Player/PlayerRenderer.php
+++ b/app/Player/PlayerRenderer.php
@@ -363,8 +363,10 @@ final class PlayerRenderer
     /**
      * Interactive "up next" overlay: a centered modal listing the queued tracks
      * (track — artist), the highlighted row moved with ↑↓, ⏎ to play the chosen
-     * up-next track, esc to close. An inline status (e.g. a no-device note) is
-     * surfaced in the footer without closing the overlay, like the palette/picker.
+     * up-next track, `/` to layer the search palette over the queue (add tracks
+     * in context), `n` to skip the current track, esc to close. An inline status
+     * (e.g. a no-device note) is surfaced in the footer without closing the
+     * overlay, like the palette/picker.
      *
      * WHY a sibling of searchOverlay (not folded into it): same centered-modal
      * shell and selection model, but the data is the raw Spotify queue shape and
@@ -395,7 +397,7 @@ final class PlayerRenderer
             : $this->windowedSelectableList($labels, $selectedIndex);
 
         // Unified footer shape, shared with the search palette and playlist picker.
-        $footer = $this->modalFooter('↑↓ select · ⏎ play · esc close', $status);
+        $footer = $this->modalFooter('↑↓ select · ⏎ play · / search · n skip · esc close', $status);
 
         $contents = $this->listContents($bodyLines, $footer);
 
@@ -519,12 +521,17 @@ final class PlayerRenderer
             ->titleStyle($theme->heading())
             ->widget($contents);
 
+        // 70% (not 60%): the widest unified footer — the queue overlay's
+        // '↑↓ select · ⏎ play · / search · n skip · esc close' — is ~50 cells,
+        // and at 60% of an 80-col terminal the modal's inner width (~46) clipped
+        // 'esc close' clean off. 70% (~54 inner) fits every footer AND the full
+        // TEXT_WIDTH(48) row labels that 60% was silently truncating.
         return GridWidget::default()
             ->direction(Direction::Horizontal)
             ->constraints(
-                Constraint::percentage(20),
-                Constraint::percentage(60),
-                Constraint::percentage(20),
+                Constraint::percentage(15),
+                Constraint::percentage(70),
+                Constraint::percentage(15),
             )
             ->widgets(
                 ParagraphWidget::fromString(''),

--- a/tests/Feature/PremiumPlayerCommandTest.php
+++ b/tests/Feature/PremiumPlayerCommandTest.php
@@ -157,6 +157,87 @@ describe('PremiumPlayerCommand', function (): void {
     });
 
     /**
+     * The queue overlay is an editor now: `/` layers the search palette over the
+     * queue (the loop reads the 'search' outcome and opens the palette with
+     * returnTo=queue, leaving the queue state intact underneath).
+     */
+    it('returns the search outcome on / from the queue overlay without closing it', function (): void {
+        $player = Mockery::mock(SpotifyPlayerService::class);
+
+        $command = new PremiumPlayerCommand;
+        $method = new ReflectionMethod($command, 'handleQueueEvent');
+
+        $queue = [
+            'active' => true,
+            'selected' => 0,
+            'status' => '',
+            'items' => [['uri' => 'spotify:track:abc']],
+        ];
+        $args = [\PhpTui\Term\Event\CharKeyEvent::new('/'), $player, &$queue];
+        $outcome = $method->invokeArgs($command, $args);
+
+        expect($outcome)->toBe('search')
+            ->and($queue['active'])->toBeTrue(); // queue stays underneath the palette
+    });
+
+    /**
+     * `n` from the queue overlay skips the current track. The queue shifts when
+     * its head starts playing, so the handler re-snapshots the items in place
+     * (selection clamped) and keeps the overlay open.
+     */
+    it('skips the current track on n and re-snapshots the queue in place', function (): void {
+        $player = Mockery::mock(SpotifyPlayerService::class);
+        $player->shouldReceive('next')->once();
+        $player->shouldReceive('getQueue')->once()->andReturn([
+            'queue' => [['uri' => 'spotify:track:next', 'name' => 'Next Up']],
+        ]);
+
+        $command = new PremiumPlayerCommand;
+        $method = new ReflectionMethod($command, 'handleQueueEvent');
+
+        $queue = [
+            'active' => true,
+            'selected' => 1, // beyond the post-skip length → must clamp to 0
+            'status' => 'stale note',
+            'items' => [
+                ['uri' => 'spotify:track:a'],
+                ['uri' => 'spotify:track:b'],
+            ],
+        ];
+        $args = [\PhpTui\Term\Event\CharKeyEvent::new('n'), $player, &$queue];
+        $outcome = $method->invokeArgs($command, $args);
+
+        expect($outcome)->toBe('refresh')                       // panel refetches now-playing
+            ->and($queue['active'])->toBeTrue()                 // overlay stays open
+            ->and($queue['items'])->toHaveCount(1)              // fresh snapshot, not the stale pair
+            ->and($queue['items'][0]['uri'])->toBe('spotify:track:next')
+            ->and($queue['selected'])->toBe(0)                  // clamped to the new length
+            ->and($queue['status'])->toBe('');                  // stale status cleared
+    });
+
+    it('keeps the queue overlay open with an inline status when the skip fails', function (): void {
+        $player = Mockery::mock(SpotifyPlayerService::class);
+        $player->shouldReceive('next')->once()->andThrow(new Exception('No active device'));
+
+        $command = new PremiumPlayerCommand;
+        $method = new ReflectionMethod($command, 'handleQueueEvent');
+
+        $queue = [
+            'active' => true,
+            'selected' => 0,
+            'status' => '',
+            'items' => [['uri' => 'spotify:track:abc']],
+        ];
+        $args = [\PhpTui\Term\Event\CharKeyEvent::new('n'), $player, &$queue];
+        $outcome = $method->invokeArgs($command, $args);
+
+        expect($outcome)->toBe('none')
+            ->and($queue['active'])->toBeTrue()
+            ->and($queue['status'])->toBe('No active device')
+            ->and($queue['items'])->toHaveCount(1); // snapshot untouched on failure
+    });
+
+    /**
      * The now-playing panel gained an "up next" peek, resolved on track change from
      * the queue. peekUpNext() formats the next track as "Title — Artist" (or null).
      */

--- a/tests/Unit/Player/PlayerRendererTest.php
+++ b/tests/Unit/Player/PlayerRendererTest.php
@@ -262,6 +262,26 @@ describe('PlayerRenderer', function (): void {
             ->toContain('close');
     });
 
+    it('advertises the search-from-queue and skip actions in the queue footer at the 12-row viewport', function (): void {
+        // The queue overlay is an EDITOR now: `/` layers the search palette over
+        // the queue (add tracks in context) and `n` skips the current track. Both
+        // hints must survive — un-clipped — at the real inline(12) size; a hint
+        // the footer can't show may as well not exist.
+        $renderer = new PlayerRenderer(PlayerTheme::forMood('chill'));
+
+        $queue = [
+            ['name' => 'Dreams', 'uri' => 'spotify:track:1', 'artists' => [['name' => 'Fleetwood Mac']]],
+            ['name' => 'Black', 'uri' => 'spotify:track:2', 'artists' => [['name' => 'Pearl Jam']]],
+        ];
+
+        $out = renderPremiumPlayerInline($renderer->queueOverlay($queue, 0));
+
+        expect($out)
+            ->toContain('/ search')         // open the palette over the queue
+            ->toContain('n skip')           // skip the current track
+            ->toContain('esc close');       // the END of the footer — nothing clipped
+    });
+
     it('renders the playlist overlay with visible items at the real 12-row inline viewport', function (): void {
         // Same regression guard for `l`: visible at inline(12), footer not clipped.
         $renderer = new PlayerRenderer(PlayerTheme::forMood('hype'));


### PR DESCRIPTION
## Why

The premium player's queue overlay (`u`) could only *look* at the queue — scroll, jump-play, close. Todo #32 turns it into an editor. But Spotify's Web API is **append + read only** on the playback queue (no delete, no reorder, no move — confirmed), and the full-queue-rebuild workaround was explicitly declined as too disruptive. So "editor" reduces to the two operations the API can actually do, both of which were missing from the queue context:

1. **Search from the queue** — you're looking at what's coming up and want to add something *right there*, not close the overlay, reopen search, add, reopen the queue.
2. **Skip** the current track while watching the queue shift.

## What

- **`/` from the queue** layers the search palette over the queue overlay. The queue state stays intact underneath; a new `returnTo` pointer on the search state records where to land. Closing the palette (esc, or a successful ⏎ play) drops back onto a **fresh queue snapshot** (selection clamped) so a just-added track is visible immediately. `a` keeps the palette open to queue several in a row, exactly as from the main view. Plain `/` from the main view behaves as before (`returnTo = null`).
- **`n` from the queue** skips the current track without leaving the overlay, then re-snapshots the queue in place (it shifts when its head starts playing). A no-device failure surfaces as the same inline-status contract as ⏎ play.
- **Footer** now advertises the new keys: `↑↓ select · ⏎ play · / search · n skip · esc close`. That string is ~50 cells and the shared centered modal at 60% width clipped `esc close` clean off — so the modal widens to **70%**, which fits every unified footer *and* the full `TEXT_WIDTH(48)` row labels that 60% was already silently truncating.

## Out of scope (API limits, user decision)

Delete from queue, move up/down, reorder — Spotify exposes no endpoint; the only workaround is a disruptive full-queue rebuild via `play(uris=…)`, which was declined. Not built.

## Verification

- Targeted: `vendor/bin/pest tests/Unit/Player/ tests/Feature/PremiumPlayerCommandTest.php` — 89 passed (291 assertions).
- Full suite: `composer test` — **637 passed (1920 assertions)**, exit 0.
- `composer lint` — pass.
- New tests: queue-footer hints pinned un-clipped at the real 12-row inline viewport; `handleQueueEvent` driven directly for `/` → search outcome, `n` skip + re-snapshot + clamp + status-clear, and skip-failure inline status.

Builds on the premium player from #136 (now merged), so this diff is just the 2 queue-editor commits.