### PR TITLE
feat(player): lyrics overlay (y) via lrclib

### DIFF
--- a/app/Commands/PremiumPlayerCommand.php
+++ b/app/Commands/PremiumPlayerCommand.php
@@ -6,6 +6,7 @@ namespace App\Commands;
 
 use App\Commands\Concerns\RequiresSpotifyConfig;
 use App\Player\GenreMoodMap;
+use App\Player\LyricsProvider;
 use App\Player\PlayerRenderer;
 use App\Player\PlayerTheme;
 use App\Player\PlayerViewModel;
@@ -82,9 +83,11 @@ class PremiumPlayerCommand extends Command
 
     private const PLAYLIST = 'playlist';
 
+    private const LYRICS = 'lyrics';
+
     private const NONE = 'none';
 
-    public function handle(SpotifyPlayerService $player, SpotifyDiscoveryService $discovery, GenreMoodMap $genreMoodMap): int
+    public function handle(SpotifyPlayerService $player, SpotifyDiscoveryService $discovery, GenreMoodMap $genreMoodMap, LyricsProvider $lyricsProvider): int
     {
         if (! $this->ensureConfigured()) {
             return self::FAILURE;
@@ -99,14 +102,14 @@ class PremiumPlayerCommand extends Command
             return self::FAILURE;
         }
 
-        return $this->runLoop($player, $discovery, $genreMoodMap);
+        return $this->runLoop($player, $discovery, $genreMoodMap, $lyricsProvider);
     }
 
     /**
      * The interactive render/input loop. Everything terminal-mutating is wrapped
      * so the terminal is ALWAYS restored, even on error or Ctrl+C.
      */
-    private function runLoop(SpotifyPlayerService $player, SpotifyDiscoveryService $discovery, GenreMoodMap $genreMoodMap): int
+    private function runLoop(SpotifyPlayerService $player, SpotifyDiscoveryService $discovery, GenreMoodMap $genreMoodMap, LyricsProvider $lyricsProvider): int
     {
         // HARD GUARD: php-tui's Terminal enables raw mode + a non-blocking stdin
         // event reader. Constructing it without a real interactive TTY (tests,
@@ -182,6 +185,12 @@ class PremiumPlayerCommand extends Command
         // no-device failure) without closing the overlay, mirroring the palette.
         $playlist = ['active' => false, 'items' => [], 'selected' => 0, 'status' => ''];
 
+        // Lyrics overlay state. 'lines' is the LyricsProvider result for the track
+        // the overlay was opened on (null = no lyrics), snapshotted ON OPEN — the
+        // provider caches per track, so reopening is free, and fetching once means
+        // the loop never does lyrics I/O per frame. 'scroll' is the top visible line.
+        $lyrics = ['active' => false, 'track' => null, 'lines' => null, 'scroll' => 0];
+
         try {
             while ($running) {
                 $now = microtime(true);
@@ -230,13 +239,13 @@ class PremiumPlayerCommand extends Command
 
                 // Force a full repaint when the surface changes (panel ↔ any overlay)
                 // so a closing overlay never leaves residue behind — see $lastSurface.
-                $surface = $this->currentSurface($search, $queue, $playlist);
+                $surface = $this->currentSurface($search, $queue, $playlist, $lyrics);
                 if ($surface !== $lastSurface) {
                     $display->clear();
                     $lastSurface = $surface;
                 }
 
-                $display->draw($this->frame($renderer, $vm, $search, $queue, $playlist));
+                $display->draw($this->frame($renderer, $vm, $search, $queue, $playlist, $lyrics));
 
                 // Drain all buffered input each tick (next() is non-blocking). Each
                 // overlay consumes keys differently; only one is ever active at a time.
@@ -268,6 +277,8 @@ class PremiumPlayerCommand extends Command
                         }
                     } elseif ($playlist['active']) {
                         $outcome = $this->handlePlaylistEvent($event, $player, $playlist);
+                    } elseif ($lyrics['active']) {
+                        $outcome = $this->handleLyricsEvent($event, $lyrics);
                     } else {
                         $outcome = $this->handleEvent($event, $player, $vm);
 
@@ -288,6 +299,19 @@ class PremiumPlayerCommand extends Command
                         // `l` opens the playlist picker; snapshot the playlists now.
                         if ($outcome === self::PLAYLIST) {
                             $playlist = ['active' => true, 'items' => $this->safePlaylists($discovery), 'selected' => 0, 'status' => ''];
+
+                            continue;
+                        }
+
+                        // `y` opens the lyrics overlay for the CURRENT track; fetch
+                        // (or cache-hit) the lyrics now, once, never per frame.
+                        if ($outcome === self::LYRICS) {
+                            $lyrics = [
+                                'active' => true,
+                                'track' => ($vm !== null && $vm->hasPlayback) ? $vm->title : null,
+                                'lines' => $this->safeLyrics($lyricsProvider, $vm),
+                                'scroll' => 0,
+                            ];
 
                             continue;
                         }
@@ -392,6 +416,7 @@ class PremiumPlayerCommand extends Command
                 '/' => self::SEARCH, // opens the in-loop search palette (no suspend)
                 'u' => self::QUEUE, // 'u' for up-next, since 'q' is quit
                 'l' => self::PLAYLIST, // opens the playlist picker overlay
+                'y' => self::LYRICS, // lyrics overlay ('y' since 'l' is playlists)
                 ' ' => $this->togglePlayback($player, $vm),
                 'n' => $this->then(fn () => $player->next()),
                 'p' => $this->then(fn () => $player->previous()),
@@ -414,16 +439,17 @@ class PremiumPlayerCommand extends Command
     }
 
     /**
-     * Choose what to draw this tick: whichever overlay is open (search, queue, or
-     * playlist), otherwise the now-playing panel (or the empty state). All are drawn
-     * into the same inline viewport, so an overlay reads as a centered modal over
-     * the player. At most one overlay is ever active at a time.
+     * Choose what to draw this tick: whichever overlay is open (search, queue,
+     * playlist, or lyrics), otherwise the now-playing panel (or the empty state).
+     * All are drawn into the same inline viewport, so an overlay reads as a
+     * centered modal over the player. At most one overlay is ever active at a time.
      *
      * @param  array<string, mixed>  $search
      * @param  array<string, mixed>  $queue
      * @param  array<string, mixed>  $playlist
+     * @param  array<string, mixed>  $lyrics
      */
-    private function frame(PlayerRenderer $renderer, ?PlayerViewModel $vm, array $search, array $queue, array $playlist): Widget
+    private function frame(PlayerRenderer $renderer, ?PlayerViewModel $vm, array $search, array $queue, array $playlist, array $lyrics): Widget
     {
         if ($search['active']) {
             return $renderer->searchOverlay($search['query'], $search['results'], $search['selected'], $search['status']);
@@ -435,6 +461,10 @@ class PremiumPlayerCommand extends Command
 
         if ($playlist['active']) {
             return $renderer->playlistOverlay($playlist['items'], $playlist['selected'], $playlist['status']);
+        }
+
+        if ($lyrics['active']) {
+            return $renderer->lyricsOverlay($lyrics['track'], $lyrics['lines'], $lyrics['scroll']);
         }
 
         return ($vm !== null && $vm->hasPlayback) ? $renderer->nowPlaying($vm) : $renderer->empty();
@@ -449,13 +479,15 @@ class PremiumPlayerCommand extends Command
      * @param  array<string, mixed>  $search
      * @param  array<string, mixed>  $queue
      * @param  array<string, mixed>  $playlist
+     * @param  array<string, mixed>  $lyrics
      */
-    private function currentSurface(array $search, array $queue, array $playlist): string
+    private function currentSurface(array $search, array $queue, array $playlist, array $lyrics): string
     {
         return match (true) {
             $search['active'] => 'search',
             $queue['active'] => 'queue',
             $playlist['active'] => 'playlist',
+            $lyrics['active'] => 'lyrics',
             default => 'panel',
         };
     }
@@ -751,6 +783,74 @@ class PremiumPlayerCommand extends Command
         }
 
         return self::NONE;
+    }
+
+    /**
+     * Handle a keypress while the lyrics overlay is open: ↑↓ scroll the visible
+     * window over the lyric lines, esc closes, Ctrl+C still quits the whole
+     * player. No per-line action — lyrics are read, not selected — so this is
+     * the simplest of the overlay handlers. Pure state mutation, NO API calls:
+     * the lines were snapshotted when the overlay opened.
+     *
+     * @param  array<string, mixed>  $lyrics
+     */
+    private function handleLyricsEvent(object $event, array &$lyrics): string
+    {
+        if ($event instanceof CodedKeyEvent) {
+            return match ($event->code) {
+                KeyCode::Esc => $this->closeOverlay($lyrics),
+                KeyCode::Up => $this->scrollLyrics($lyrics, -1),
+                KeyCode::Down => $this->scrollLyrics($lyrics, 1),
+                default => self::NONE,
+            };
+        }
+
+        if ($event instanceof CharKeyEvent && $event->char === "\x03") {
+            return self::QUIT;
+        }
+
+        return self::NONE;
+    }
+
+    /**
+     * Slide the lyrics window, clamped so the last page stays full — the offset
+     * never scrolls past (line count − visible rows), using the renderer's OWN
+     * window constant so the clamp and the rendered slice can't drift apart.
+     *
+     * @param  array<string, mixed>  $lyrics
+     */
+    private function scrollLyrics(array &$lyrics, int $delta): string
+    {
+        $count = is_array($lyrics['lines']) ? count($lyrics['lines']) : 0;
+        $maxScroll = max(0, $count - PlayerRenderer::LYRICS_ROWS);
+        $lyrics['scroll'] = max(0, min($maxScroll, $lyrics['scroll'] + $delta));
+
+        return self::NONE;
+    }
+
+    /**
+     * Fetch the current track's lyrics without ever throwing — no playback, no
+     * match, or any provider failure all collapse to null, which the overlay
+     * renders as the calm "No lyrics found" state. lrclib matches on duration
+     * in SECONDS when known (the VM carries ms).
+     *
+     * @return list<string>|null
+     */
+    private function safeLyrics(LyricsProvider $provider, ?PlayerViewModel $vm): ?array
+    {
+        if ($vm === null || ! $vm->hasPlayback) {
+            return null;
+        }
+
+        try {
+            return $provider->lines(
+                $vm->artist,
+                $vm->title,
+                $vm->durationMs > 0 ? intdiv($vm->durationMs, 1000) : null,
+            );
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/app/Player/LyricsProvider.php
+++ b/app/Player/LyricsProvider.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Player;
+
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+/**
+ * Fetches lyrics for a track from lrclib.net — a free, no-auth lyrics API.
+ *
+ * WHY a standalone lane (mirroring {@see AlbumArtRenderer}'s shape): Spotify's
+ * Web API does not expose lyrics at all, so the player needs a second remote
+ * source — which means network I/O, an external contract, and failure modes
+ * that must NEVER reach the draw loop. Keeping the fetch behind this single
+ * lines() seam makes it Http::fake-testable and lets the command treat lyrics
+ * exactly like album art: ask once, render whatever comes back, degrade to a
+ * calm empty state on any miss.
+ *
+ * Contract: lines() returns the plain (unsynced) lyrics as a list of display
+ * lines, or null for ANY failure — no match, network error, blank metadata,
+ * instrumental track. Callers branch on null, never on exceptions.
+ */
+final class LyricsProvider
+{
+    /** lrclib's exact-match lookup: artist + track (+ optional duration). */
+    private const ENDPOINT = 'https://lrclib.net/api/get';
+
+    /**
+     * Short timeout: lyrics are cosmetic and fetched from inside the player's
+     * interactive loop — a slow third-party API must stall the UI briefly at
+     * worst, never hang it.
+     */
+    private const TIMEOUT_SECONDS = 4;
+
+    /**
+     * Per-track result cache. Values: the lyric lines (success) or null (no
+     * match / failure). array_key_exists distinguishes "never tried" from
+     * "tried and missed" so reopening the overlay on the same track never
+     * refetches — the same convention as AlbumArtRenderer's decode cache.
+     *
+     * @var array<string, list<string>|null>
+     */
+    private static array $cache = [];
+
+    /**
+     * The lyrics for a track as displayable lines, or null when unavailable.
+     *
+     * Duration (seconds) is optional but sharpens lrclib's exact-match lookup
+     * when known; pass null when the player has no duration.
+     *
+     * @return list<string>|null
+     */
+    public function lines(string $artist, string $title, ?int $durationSeconds = null): ?array
+    {
+        // Nothing to look up — don't burn a request (or a cache slot) on it.
+        if (trim($artist) === '' || trim($title) === '') {
+            return null;
+        }
+
+        $key = mb_strtolower(trim($artist).'|'.trim($title).'|'.($durationSeconds ?? ''));
+
+        if (array_key_exists($key, self::$cache)) {
+            return self::$cache[$key];
+        }
+
+        return self::$cache[$key] = $this->fetch($artist, $title, $durationSeconds);
+    }
+
+    /**
+     * Hit lrclib and normalise the response into display lines.
+     *
+     * Only plainLyrics is consumed: synced (LRC-timestamped) highlighting is a
+     * possible future nicety, but plain scrollable lines are the contract the
+     * overlay renders today.
+     *
+     * @return list<string>|null
+     */
+    private function fetch(string $artist, string $title, ?int $durationSeconds): ?array
+    {
+        try {
+            $query = ['artist_name' => $artist, 'track_name' => $title];
+
+            if ($durationSeconds !== null && $durationSeconds > 0) {
+                $query['duration'] = $durationSeconds;
+            }
+
+            $response = Http::timeout(self::TIMEOUT_SECONDS)->get(self::ENDPOINT, $query);
+
+            if (! $response->successful()) {
+                return null; // 404 = no match; any other non-2xx is equally "no lyrics"
+            }
+
+            $plain = $response->json('plainLyrics');
+        } catch (Throwable) {
+            // DNS, TLS, connection, timeout — all collapse to "no lyrics".
+            return null;
+        }
+
+        // Instrumental tracks come back with empty/null plainLyrics.
+        if (! is_string($plain) || trim($plain) === '') {
+            return null;
+        }
+
+        // Split on any newline convention; keep interior blank lines (stanza
+        // breaks) but trim the trailing whitespace lrclib sometimes pads with.
+        $lines = preg_split('/\R/u', trim($plain)) ?: [];
+
+        return array_values(array_map(rtrim(...), $lines));
+    }
+}

--- a/app/Player/LyricsProvider.php
+++ b/app/Player/LyricsProvider.php
@@ -107,6 +107,6 @@ final class LyricsProvider
         // breaks) but trim the trailing whitespace lrclib sometimes pads with.
         $lines = preg_split('/\R/u', trim($plain)) ?: [];
 
-        return array_values(array_map(rtrim(...), $lines));
+        return array_map(rtrim(...), $lines);
     }
 }

--- a/app/Player/PlayerRenderer.php
+++ b/app/Player/PlayerRenderer.php
@@ -61,6 +61,14 @@ final class PlayerRenderer
     private const SEARCH_RESULTS = 8;
 
     /**
+     * Visible lyric lines per page in the lyrics overlay — same row budget as the
+     * other modals so the footer survives the 12-row inline viewport. PUBLIC so
+     * the command can clamp its scroll offset to the identical window without
+     * duplicating (and inevitably de-syncing) the constant.
+     */
+    public const LYRICS_ROWS = 8;
+
+    /**
      * Fixed cell width of the progress meter. Fixed (not flexible) because we render
      * the bar's TRACK ourselves — see progressBar() — which needs a known length.
      * Sits comfortably inside the art-narrowed info column beside the time label.
@@ -441,6 +449,61 @@ final class PlayerRenderer
     }
 
     /**
+     * Lyrics overlay: a centered modal showing the current track's lyrics, a
+     * LYRICS_ROWS window at a time, scrolled with ↑↓ from the given line offset.
+     *
+     * WHY scroll-not-select (unlike the sibling overlays): lyrics are prose to
+     * READ, not rows to act on — there is no per-line action, so the ▶ selection
+     * marker would be noise. The window slides over the lines instead, and the
+     * footer carries a "from–to / total" position cue so a long lyric sheet
+     * doesn't feel bottomless. Null/empty lines (no match, network failure,
+     * instrumental) render the calm "No lyrics found" state — same contract as
+     * the other overlays' empty states, never a crash.
+     *
+     * @param  list<string>|null  $lines  null = no lyrics available for this track
+     */
+    public function lyricsOverlay(?string $trackLabel, ?array $lines, int $scroll, string $status = ''): Widget
+    {
+        $theme = $this->theme;
+
+        if ($lines === null || $lines === []) {
+            $bodyLines = [Line::fromSpans(Span::styled('No lyrics found', $theme->dim()))];
+            $position = '';
+        } else {
+            $count = count($lines);
+
+            // Clamp defensively: the command clamps too, but a stale offset after
+            // a track change must window safely rather than render past the end.
+            $start = max(0, min($scroll, max(0, $count - self::LYRICS_ROWS)));
+
+            $bodyLines = array_map(
+                fn (string $line): Line => Line::fromSpans(
+                    Span::styled($this->truncateDisplay($line, self::TEXT_WIDTH), $theme->text())
+                ),
+                array_slice($lines, $start, self::LYRICS_ROWS),
+            );
+
+            // Position cue only when there is actually more than one page.
+            $position = $count > self::LYRICS_ROWS
+                ? ($start + 1).'–'.min($count, $start + self::LYRICS_ROWS).' / '.$count
+                : '';
+        }
+
+        // Unified footer shape; the scroll position rides the status slot (an
+        // explicit status — e.g. a fetch note — takes precedence when present).
+        $footer = $this->modalFooter('↑↓ scroll · esc close', $status !== '' ? $status : $position);
+
+        $contents = $this->listContents($bodyLines, $footer);
+
+        // Title carries the track so the sheet is self-identifying: "📝 Lyrics — Song".
+        $title = ' '.$theme->icon('lyrics').' Lyrics'
+            .($trackLabel !== null && $trackLabel !== '' ? ' — '.$this->truncateDisplay($trackLabel, 32) : '')
+            .' ';
+
+        return $this->centeredModal($title, $contents);
+    }
+
+    /**
      * Compose a modal footer: the static key hints, prefixed with any inline status
      * (a no-device note, a "+ queued" confirm). One helper so the search palette,
      * queue overlay and playlist picker render the status/hints identically — the
@@ -650,6 +713,7 @@ final class PlayerRenderer
                 ['/', 'search'],
                 ['u', 'queue'],
                 ['l', 'playlists'],
+                ['y', 'lyrics'], // 'y' because 'l' (the natural mnemonic) is taken by playlists
                 ['q', 'quit'],
             ]),
         ];

--- a/app/Player/PlayerTheme.php
+++ b/app/Player/PlayerTheme.php
@@ -32,7 +32,7 @@ final class PlayerTheme
 
     /**
      * @param  string  $mood  One of config('autopilot.mood_presets') keys, or
-     *                         'neutral' when the mood is unknown (graceful default).
+     *                        'neutral' when the mood is unknown (graceful default).
      */
     public function __construct(private readonly string $mood = 'neutral') {}
 
@@ -148,6 +148,7 @@ final class PlayerTheme
             'search' => '🔍',
             'queue' => '📋',
             'playlist' => '📚',
+            'lyrics' => '📝',
             'device' => '📱',
             'music' => '🎵',
             'artist' => '👤',

--- a/tests/Feature/PremiumPlayerCommandTest.php
+++ b/tests/Feature/PremiumPlayerCommandTest.php
@@ -42,18 +42,19 @@ describe('PremiumPlayerCommand', function (): void {
     it('names the active surface so the loop can clear across transitions', function (): void {
         $command = new PremiumPlayerCommand;
         $method = new ReflectionMethod($command, 'currentSurface');
-        $surface = fn (array $s, array $q, array $p): string => $method->invoke($command, $s, $q, $p);
+        $surface = fn (array $s, array $q, array $p, array $y): string => $method->invoke($command, $s, $q, $p, $y);
 
         $off = ['active' => false];
         $on = ['active' => true];
 
         // No overlay open → the now-playing panel.
-        expect($surface($off, $off, $off))->toBe('panel');
+        expect($surface($off, $off, $off, $off))->toBe('panel');
 
         // Each overlay reports its own name; search wins the precedence when checked.
-        expect($surface($on, $off, $off))->toBe('search');
-        expect($surface($off, $on, $off))->toBe('queue');
-        expect($surface($off, $off, $on))->toBe('playlist');
+        expect($surface($on, $off, $off, $off))->toBe('search');
+        expect($surface($off, $on, $off, $off))->toBe('queue');
+        expect($surface($off, $off, $on, $off))->toBe('playlist');
+        expect($surface($off, $off, $off, $on))->toBe('lyrics');
     });
 
     /**
@@ -267,6 +268,98 @@ describe('PremiumPlayerCommand', function (): void {
 
         expect($method->invoke($command, $empty))->toBeNull()
             ->and($method->invoke($command, $failing))->toBeNull();
+    });
+
+    /**
+     * The lyrics overlay (y) scrolls a fixed window over the fetched lines.
+     * Drive the handler directly, like the queue tests — esc closes, ↑↓ slide
+     * the window clamped to (count − visible rows), Ctrl+C quits the player.
+     */
+    it('scrolls the lyrics window with arrows, clamped to the last full page', function (): void {
+        $command = new PremiumPlayerCommand;
+        $method = new ReflectionMethod($command, 'handleLyricsEvent');
+
+        // 10 lines with an 8-row window → max scroll offset is 2.
+        $lyrics = [
+            'active' => true,
+            'track' => 'Song',
+            'lines' => array_map(fn (int $i): string => "Line {$i}", range(1, 10)),
+            'scroll' => 0,
+        ];
+
+        $down = \PhpTui\Term\Event\CodedKeyEvent::new(\PhpTui\Term\KeyCode::Down);
+        $up = \PhpTui\Term\Event\CodedKeyEvent::new(\PhpTui\Term\KeyCode::Up);
+
+        // ↑ at the top is a no-op (clamped at 0).
+        $args = [$up, &$lyrics];
+        expect($method->invokeArgs($command, $args))->toBe('none')
+            ->and($lyrics['scroll'])->toBe(0);
+
+        // ↓ three times: 0 → 1 → 2 → clamped at 2 (10 lines − 8 visible).
+        foreach (range(1, 3) as $i) {
+            $args = [$down, &$lyrics];
+            $method->invokeArgs($command, $args);
+        }
+        expect($lyrics['scroll'])->toBe(2);
+
+        // esc closes the overlay; Ctrl+C still quits the whole player.
+        $esc = \PhpTui\Term\Event\CodedKeyEvent::new(\PhpTui\Term\KeyCode::Esc);
+        $args = [$esc, &$lyrics];
+        expect($method->invokeArgs($command, $args))->toBe('none')
+            ->and($lyrics['active'])->toBeFalse();
+
+        $args = [\PhpTui\Term\Event\CharKeyEvent::new("\x03"), &$lyrics];
+        expect($method->invokeArgs($command, $args))->toBe('quit');
+    });
+
+    it('does not scroll when there are no lyric lines', function (): void {
+        $command = new PremiumPlayerCommand;
+        $method = new ReflectionMethod($command, 'handleLyricsEvent');
+
+        // null lines (no match / failure) → ↓ stays clamped at 0, never errors.
+        $lyrics = ['active' => true, 'track' => null, 'lines' => null, 'scroll' => 0];
+
+        $down = \PhpTui\Term\Event\CodedKeyEvent::new(\PhpTui\Term\KeyCode::Down);
+        $args = [$down, &$lyrics];
+
+        expect($method->invokeArgs($command, $args))->toBe('none')
+            ->and($lyrics['scroll'])->toBe(0);
+    });
+
+    /**
+     * safeLyrics() is the loop's crash-proof seam to the LyricsProvider: no
+     * playback → null without ever touching the network; with playback it asks
+     * lrclib with the track's artist/title/duration (ms → seconds). Driven with
+     * Http::fake (the provider is final, so we exercise the real one).
+     */
+    it('skips the lyrics lookup when nothing is playing and fetches by track when playing', function (): void {
+        // Fresh provider cache so this test controls its own fetches.
+        (new ReflectionProperty(App\Player\LyricsProvider::class, 'cache'))->setValue(null, []);
+        Illuminate\Support\Facades\Http::fake([
+            'lrclib.net/*' => Illuminate\Support\Facades\Http::response([
+                'plainLyrics' => 'Is this the real life?',
+            ]),
+        ]);
+
+        $command = new PremiumPlayerCommand;
+        $method = new ReflectionMethod($command, 'safeLyrics');
+        $provider = new App\Player\LyricsProvider;
+
+        // No playback (or no VM at all) → null, and lrclib is never consulted.
+        $idle = App\Player\PlayerViewModel::fromPlayback(null);
+        expect($method->invoke($command, $provider, $idle))->toBeNull()
+            ->and($method->invoke($command, $provider, null))->toBeNull();
+        Illuminate\Support\Facades\Http::assertNothingSent();
+
+        // Playing → fetches by artist/title with the duration in SECONDS (354000ms).
+        $playing = App\Player\PlayerViewModel::fromPlayback([
+            'name' => 'Bohemian Rhapsody', 'artist' => 'Queen', 'album' => 'A Night at the Opera',
+            'is_playing' => true, 'progress_ms' => 1_000, 'duration_ms' => 354_000,
+        ]);
+        expect($method->invoke($command, $provider, $playing))->toBe(['Is this the real life?']);
+        Illuminate\Support\Facades\Http::assertSent(
+            fn ($request): bool => str_contains($request->url(), 'duration=354')
+        );
     });
 
 });

--- a/tests/Unit/Player/LyricsProviderTest.php
+++ b/tests/Unit/Player/LyricsProviderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Player\LyricsProvider;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+// The provider talks through the Http facade, so this file (unlike its pure
+// php-tui siblings in Unit/Player) needs the Laravel TestCase to boot the app.
+uses(TestCase::class);
+
+/**
+ * WHY Http::fake throughout: the provider's only job is turning an lrclib
+ * response (or any failure) into displayable lines or null — so every contract
+ * branch (match, no match, network failure, instrumental, caching) is pinned
+ * without a single real request.
+ */
+describe('LyricsProvider', function (): void {
+
+    beforeEach(function (): void {
+        // Clear the static per-track cache so each test controls its own fetches
+        // (same convention as AlbumArtRenderer's decode-cache reset).
+        (new ReflectionProperty(LyricsProvider::class, 'cache'))->setValue(null, []);
+    });
+
+    it('returns the plain lyrics as lines on a match', function (): void {
+        Http::fake([
+            'lrclib.net/*' => Http::response([
+                'plainLyrics' => "Is this the real life?\nIs this just fantasy?\n\nCaught in a landslide",
+                'syncedLyrics' => '[00:01.00] Is this the real life?',
+            ]),
+        ]);
+
+        $lines = (new LyricsProvider)->lines('Queen', 'Bohemian Rhapsody', 354);
+
+        // Lines split on newlines, interior blanks kept as stanza breaks.
+        expect($lines)->toBe([
+            'Is this the real life?',
+            'Is this just fantasy?',
+            '',
+            'Caught in a landslide',
+        ]);
+
+        // The lookup carries artist/track/duration so lrclib can exact-match.
+        Http::assertSent(fn ($request): bool => str_contains($request->url(), 'lrclib.net/api/get')
+            && str_contains($request->url(), 'artist_name=Queen')
+            && str_contains($request->url(), 'duration=354'));
+    });
+
+    it('returns null when lrclib has no match', function (): void {
+        Http::fake([
+            'lrclib.net/*' => Http::response(['message' => 'Failed to find specified track'], 404),
+        ]);
+
+        expect((new LyricsProvider)->lines('Nobody', 'Unknown Song'))->toBeNull();
+    });
+
+    it('returns null on a network failure instead of throwing', function (): void {
+        Http::fake([
+            'lrclib.net/*' => fn () => throw new ConnectionException('timeout'),
+        ]);
+
+        expect((new LyricsProvider)->lines('Queen', 'Bohemian Rhapsody'))->toBeNull();
+    });
+
+    it('returns null for instrumental tracks with empty lyrics', function (): void {
+        Http::fake([
+            'lrclib.net/*' => Http::response(['plainLyrics' => '', 'instrumental' => true]),
+        ]);
+
+        expect((new LyricsProvider)->lines('Explosions in the Sky', 'Your Hand in Mine'))->toBeNull();
+    });
+
+    it('skips the request entirely for blank artist or title', function (): void {
+        Http::fake();
+
+        $provider = new LyricsProvider;
+
+        expect($provider->lines('', 'Song'))->toBeNull()
+            ->and($provider->lines('Artist', '  '))->toBeNull();
+
+        Http::assertNothingSent();
+    });
+
+    it('caches per track so reopening the overlay never refetches', function (): void {
+        Http::fake([
+            'lrclib.net/*' => Http::response(['plainLyrics' => 'La la la']),
+        ]);
+
+        $provider = new LyricsProvider;
+        $first = $provider->lines('Artist', 'Song', 200);
+        $second = $provider->lines('Artist', 'Song', 200);
+
+        expect($first)->toBe(['La la la'])
+            ->and($second)->toBe(['La la la']);
+
+        // The miss is cached too: a second lookup of a known-missing track is free.
+        Http::assertSentCount(1);
+    });
+
+    it('caches a miss so a failing track is not re-queried every open', function (): void {
+        Http::fake([
+            'lrclib.net/*' => Http::response([], 404),
+        ]);
+
+        $provider = new LyricsProvider;
+
+        expect($provider->lines('Nobody', 'Nothing'))->toBeNull()
+            ->and($provider->lines('Nobody', 'Nothing'))->toBeNull();
+
+        Http::assertSentCount(1);
+    });
+
+});

--- a/tests/Unit/Player/PlayerRendererTest.php
+++ b/tests/Unit/Player/PlayerRendererTest.php
@@ -360,6 +360,82 @@ describe('PlayerRenderer', function (): void {
             ->and(substr_count($out, '▶'))->toBe(1); // exactly one highlighted row
     });
 
+    it('renders the lyrics overlay with visible lines at the real 12-row inline viewport', function (): void {
+        // Same regression guard as the other overlays: the live player draws into
+        // inline(12); lyrics that clipped to nothing would make `y` read as a no-op.
+        $renderer = new PlayerRenderer(PlayerTheme::forMood('chill'));
+
+        $lines = ['Is this the real life?', 'Is this just fantasy?', 'Caught in a landslide'];
+
+        $out = renderPremiumPlayerInline($renderer->lyricsOverlay('Bohemian Rhapsody', $lines, 0));
+
+        expect($out)
+            ->toContain('Lyrics')                    // overlay title
+            ->toContain('Bohemian Rhapsody')         // self-identifying track label
+            ->toContain('Is this the real life?')    // lyric lines visible
+            ->toContain('Caught in a landslide')
+            ->toContain('scroll')                    // footer hint pinned, not clipped
+            ->toContain('esc close')                 // the END of the footer survives
+            ->not->toContain('▶ ');                  // read-only: no selection marker
+    });
+
+    it('windows long lyrics from the scroll offset with a position cue', function (): void {
+        $renderer = new PlayerRenderer(PlayerTheme::forMood('chill'));
+
+        // 20 lines, 8-row window, scrolled to offset 5 → lines 6–13 visible.
+        $lines = array_map(fn (int $i): string => "Lyric line {$i}", range(1, 20));
+
+        $out = renderPremiumPlayer($renderer->lyricsOverlay('Song', $lines, 5));
+
+        expect($out)
+            ->toContain('Lyric line 6')      // window starts at the offset
+            ->toContain('Lyric line 13')     // …and shows a full page
+            ->not->toContain('Lyric line 1 ') // above the window
+            ->not->toContain('Lyric line 14') // below the window
+            ->toContain('6–13 / 20');        // position cue in the footer
+    });
+
+    it('clamps an overshooting lyrics scroll to the last full page', function (): void {
+        $renderer = new PlayerRenderer(PlayerTheme::forMood('chill'));
+
+        // A stale offset (e.g. after a track change) far past the end must window
+        // the LAST page, not render blank.
+        $lines = array_map(fn (int $i): string => "Lyric line {$i}", range(1, 10));
+
+        $out = renderPremiumPlayer($renderer->lyricsOverlay('Song', $lines, 99));
+
+        expect($out)
+            ->toContain('Lyric line 3')      // last page = lines 3–10
+            ->toContain('Lyric line 10')
+            ->not->toContain('Lyric line 2 ');
+    });
+
+    it('shows a calm no-lyrics state for null and empty lines at the inline viewport', function (): void {
+        $renderer = new PlayerRenderer(PlayerTheme::forMood('neutral'));
+
+        // null = no match / network failure / instrumental — all the same calm state.
+        $null = renderPremiumPlayerInline($renderer->lyricsOverlay('Song', null, 0));
+        expect($null)
+            ->toContain('Lyrics')
+            ->toContain('No lyrics found')
+            ->toContain('esc close');
+
+        $empty = renderPremiumPlayerInline($renderer->lyricsOverlay(null, [], 0));
+        expect($empty)->toContain('No lyrics found');
+    });
+
+    it('advertises the lyrics key in the now-playing legend', function (): void {
+        $renderer = new PlayerRenderer(PlayerTheme::forMood('chill'));
+
+        // `y lyrics` must be readable at the real 12-row inline viewport, with the
+        // legend's END (`q quit`) not clipped off by the new entry.
+        $out = renderPremiumPlayerInline($renderer->nowPlaying(sampleViewModel()));
+
+        expect($out)
+            ->toContain('y lyrics')
+            ->toContain('q quit');
+    });
+
     it('shows only the input and a hint for an empty search query', function (): void {
         $renderer = new PlayerRenderer(PlayerTheme::forMood('hype'));
 


### PR DESCRIPTION
Adds a scrollable lyrics overlay (y) fetched from lrclib.net via a testable LyricsProvider (cached, graceful no-lyrics/failure state); ↑↓ scroll, esc close.