### PR TITLE
feat(player): manual theme picker (t)

### DIFF
--- a/app/Commands/PremiumPlayerCommand.php
+++ b/app/Commands/PremiumPlayerCommand.php
@@ -82,6 +82,8 @@ class PremiumPlayerCommand extends Command
 
     private const PLAYLIST = 'playlist';
 
+    private const CYCLE_THEME = 'cycle-theme';
+
     private const NONE = 'none';
 
     public function handle(SpotifyPlayerService $player, SpotifyDiscoveryService $discovery, GenreMoodMap $genreMoodMap): int
@@ -123,6 +125,12 @@ class PremiumPlayerCommand extends Command
         // the mood theme when (and only when) the resolved mood actually changes, so
         // the whole surface (border/title/gauges) tints to the music.
         $mood = 'neutral';
+        // Manual theme override, cycled with `t` (null = Auto, follow the detected
+        // mood). Kept SEPARATE from $mood so auto-detection keeps tracking the
+        // music underneath — clearing the override (cycling back to Auto) lands on
+        // the current track's real mood, not a stale one. The effective theme mood
+        // is always ($themeOverride ?? $mood).
+        $themeOverride = null;
         $renderer = new PlayerRenderer(PlayerTheme::forMood($mood));
         $lastTrackKey = null;
         $moodByArtist = []; // cache: artist_id → mood, so revisited tracks are free
@@ -205,15 +213,21 @@ class PremiumPlayerCommand extends Command
                             $resolved = $this->resolveMood($player, $genreMoodMap, $payload['artist_id'] ?? null, $moodByArtist);
                             if ($resolved !== $mood) {
                                 $mood = $resolved;
-                                $renderer = new PlayerRenderer(PlayerTheme::forMood($mood));
+                                // A manual override (`t`) wins over auto-detection: keep
+                                // tracking $mood underneath, but only re-theme the surface
+                                // when the user hasn't pinned a vibe.
+                                if ($themeOverride === null) {
+                                    $renderer = new PlayerRenderer(PlayerTheme::forMood($mood));
+                                }
                             }
                             // Refresh the up-next peek on the SAME cadence as mood — once
                             // per track change, never per frame (one extra queue call, not
                             // one per second; guarded so a miss just hides the peek).
                             $upNext = $this->peekUpNext($player);
                         }
-                        // Surface the mood + up-next peek on the VM (title badge / status).
-                        $vm->mood = $mood;
+                        // Surface the EFFECTIVE mood + up-next peek on the VM (title
+                        // badge / status) — the override, when pinned, is what shows.
+                        $vm->mood = $themeOverride ?? $mood;
                         $vm->upNext = $upNext;
                     }
                 }
@@ -288,6 +302,23 @@ class PremiumPlayerCommand extends Command
                         // `l` opens the playlist picker; snapshot the playlists now.
                         if ($outcome === self::PLAYLIST) {
                             $playlist = ['active' => true, 'items' => $this->safePlaylists($discovery), 'selected' => 0, 'status' => ''];
+
+                            continue;
+                        }
+
+                        // `t` cycles the manual theme: Auto → chill → … → sleep → Auto.
+                        // Handled HERE (not in runControl) because the override and the
+                        // renderer are loop locals; runControl only names the outcome.
+                        // Rebuild immediately so the surface re-tints this frame, and
+                        // surface the effective mood on the VM so the heading badge
+                        // gives instant feedback. Landing back on Auto re-applies the
+                        // auto-detected mood that kept tracking underneath.
+                        if ($outcome === self::CYCLE_THEME) {
+                            $themeOverride = PlayerTheme::nextOverride($themeOverride);
+                            $renderer = new PlayerRenderer(PlayerTheme::forMood($themeOverride ?? $mood));
+                            if ($vm !== null && $vm->hasPlayback) {
+                                $vm->mood = $themeOverride ?? $mood;
+                            }
 
                             continue;
                         }
@@ -392,6 +423,7 @@ class PremiumPlayerCommand extends Command
                 '/' => self::SEARCH, // opens the in-loop search palette (no suspend)
                 'u' => self::QUEUE, // 'u' for up-next, since 'q' is quit
                 'l' => self::PLAYLIST, // opens the playlist picker overlay
+                't' => self::CYCLE_THEME, // cycles the manual mood theme (Auto → chill → …)
                 ' ' => $this->togglePlayback($player, $vm),
                 'n' => $this->then(fn () => $player->next()),
                 'p' => $this->then(fn () => $player->previous()),

--- a/app/Player/PlayerRenderer.php
+++ b/app/Player/PlayerRenderer.php
@@ -650,6 +650,7 @@ final class PlayerRenderer
                 ['/', 'search'],
                 ['u', 'queue'],
                 ['l', 'playlists'],
+                ['t', 'theme'],
                 ['q', 'quit'],
             ]),
         ];

--- a/app/Player/PlayerTheme.php
+++ b/app/Player/PlayerTheme.php
@@ -31,8 +31,37 @@ final class PlayerTheme
     use RendersPlayback;
 
     /**
+     * The manual theme-override cycle for the player's `t` key: null first (= Auto,
+     * follow the genre-detected mood), then every mood the moodColor()/moodLabel()
+     * vocabulary knows how to render. Lives here — not in the command — because this
+     * class owns the mood→look vocabulary; the command only walks the ring.
+     *
+     * @var list<string|null>
+     */
+    public const MOOD_CYCLE = [null, 'chill', 'flow', 'focus', 'hype', 'party', 'upbeat', 'melancholy', 'ambient', 'workout', 'sleep'];
+
+    /**
+     * Advance a manual theme override one step around {@see MOOD_CYCLE}, wrapping
+     * back to null (Auto) after the last mood. An unrecognised value resets to
+     * Auto rather than throwing — the safe landing for stale/bogus state.
+     *
+     * Pure and static so the cycle is unit-testable without driving keystrokes
+     * through the player loop.
+     */
+    public static function nextOverride(?string $current): ?string
+    {
+        $index = array_search($current, self::MOOD_CYCLE, true);
+
+        if ($index === false) {
+            return null; // unrecognised → reset to Auto
+        }
+
+        return self::MOOD_CYCLE[($index + 1) % count(self::MOOD_CYCLE)];
+    }
+
+    /**
      * @param  string  $mood  One of config('autopilot.mood_presets') keys, or
-     *                         'neutral' when the mood is unknown (graceful default).
+     *                        'neutral' when the mood is unknown (graceful default).
      */
     public function __construct(private readonly string $mood = 'neutral') {}
 

--- a/tests/Unit/Player/PlayerRendererTest.php
+++ b/tests/Unit/Player/PlayerRendererTest.php
@@ -478,6 +478,7 @@ describe('PlayerRenderer', function (): void {
             ->toContain('search')
             ->toContain('queue')
             ->toContain('playlists')
+            ->toContain('theme')
             ->toContain('shuffle')
             ->toContain('repeat')
             ->toContain('quit');

--- a/tests/Unit/Player/PlayerThemeTest.php
+++ b/tests/Unit/Player/PlayerThemeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Player\PlayerTheme;
+
+/**
+ * WHY: PlayerTheme::nextOverride() drives the player's `t` key — the manual theme
+ * picker that overrides the genre-auto-detected mood (which often lands on
+ * 'neutral'). These tests pin the cycle order (null = Auto first, then every mood
+ * the moodLabel/moodColor vocabulary renders), the wrap-around back to Auto, and
+ * the reset-to-Auto behaviour for unrecognised values, so the keybinding can stay
+ * a dumb "advance one step" in the command loop.
+ */
+it('starts the cycle at Auto and steps to the first mood', function (): void {
+    expect(PlayerTheme::nextOverride(null))->toBe('chill');
+});
+
+it('advances one mood per step in the documented order', function (?string $current, ?string $next): void {
+    expect(PlayerTheme::nextOverride($current))->toBe($next);
+})->with([
+    'chill → flow' => ['chill', 'flow'],
+    'flow → focus' => ['flow', 'focus'],
+    'focus → hype' => ['focus', 'hype'],
+    'hype → party' => ['hype', 'party'],
+    'party → upbeat' => ['party', 'upbeat'],
+    'upbeat → melancholy' => ['upbeat', 'melancholy'],
+    'melancholy → ambient' => ['melancholy', 'ambient'],
+    'ambient → workout' => ['ambient', 'workout'],
+    'workout → sleep' => ['workout', 'sleep'],
+]);
+
+it('wraps from the last mood back to Auto', function (): void {
+    expect(PlayerTheme::nextOverride('sleep'))->toBeNull();
+});
+
+it('walks the full ring back to Auto in exactly one lap', function (): void {
+    $override = null;
+
+    foreach (range(1, count(PlayerTheme::MOOD_CYCLE)) as $step) {
+        $override = PlayerTheme::nextOverride($override);
+    }
+
+    expect($override)->toBeNull();
+});
+
+it('resets unrecognised values to Auto instead of throwing', function (): void {
+    // 'neutral' is deliberately NOT in the cycle (it IS the auto fallback), and
+    // arbitrary junk must land safely too — the override always recovers to Auto.
+    expect(PlayerTheme::nextOverride('neutral'))->toBeNull()
+        ->and(PlayerTheme::nextOverride('bogus'))->toBeNull();
+});
+
+it('cycles only moods the theme vocabulary knows how to badge', function (): void {
+    foreach (PlayerTheme::MOOD_CYCLE as $mood) {
+        if ($mood === null) {
+            continue; // Auto — no badge of its own; the detected mood shows instead
+        }
+
+        // moodLabel() gives each KNOWN mood its own emoji and falls back to a
+        // generic 🎵 prefix otherwise — so a non-🎵 badge proves the mapping exists.
+        expect(PlayerTheme::forMood($mood)->moodBadge())->not->toStartWith('🎵');
+    }
+});


### PR DESCRIPTION
## What

A new `t` binding in `player:premium` cycles a **manual mood theme override** — so you can drive the vibe when genre auto-detection lands on 'neutral' (which it often does).

**Cycle**: Auto → chill → flow → focus → hype → party → upbeat → melancholy → ambient → workout → sleep → back to Auto.

## How

- `PlayerTheme::MOOD_CYCLE` + pure static `nextOverride()` own the ring — the command loop just advances one step. Unit-tested without driving keystrokes: order, wrap-around, and unknown-value reset to Auto.
- The override **wins over track-change auto-resolution**: $mood keeps tracking the music underneath, but the renderer only re-themes on track change when no override is pinned — so cycling back to Auto lands on the *current* track's real mood, never a stale one.
- `t` returns a new `CYCLE_THEME` sentinel from `runControl` (mirroring SEARCH/QUEUE/PLAYLIST), handled in the loop where `$renderer`/`$themeOverride` live. Renderer rebuilds immediately and the heading badge shows the effective mood for instant feedback.
- Footer legend gains `t theme` (pinned by the existing inline-viewport legend test).

## Tests

- New `tests/Unit/Player/PlayerThemeTest.php` — cycle order, wrap, full-lap, unknown-reset, badge vocabulary.
- Full suite: 661 passed (1976 assertions). PHPStan clean. Pint applied.

Vibe check: https://open.spotify.com/track/3tjFYV6RSFtuktYl3ZtYcq