### PR TITLE
ci: deploy vibes page to Pages (no more un-mergeable PRs)

### DIFF
--- a/.github/workflows/vibes-page.yml
+++ b/.github/workflows/vibes-page.yml
@@ -1,21 +1,40 @@
 name: Update Vibes Page
 
+# Regenerates the public commit-soundtrack page and deploys it straight to
+# GitHub Pages on every push to master.
+#
+# Why deploy instead of opening a PR: master is a protected branch (required
+# status checks + enforce_admins), and a PR opened by the Actions token can't
+# trigger those checks (GitHub's anti-recursion safeguard), so the old
+# create-pull-request flow produced PRs that could never satisfy the gate.
+# Deploying the artifact directly sidesteps branch protection entirely — no
+# commit to master, no un-mergeable PRs — while keeping the page current.
 on:
   push:
     branches: [master]
 
+# Least-privilege: only what the Pages deployment needs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time; newer pushes supersede in-flight runs.
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  update-vibes:
-    name: Regenerate Vibes Page
+  deploy-vibes:
+    name: Regenerate & Deploy Vibes Page
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # full history — the page is built from commit metadata
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -28,22 +47,20 @@ jobs:
       - name: Generate vibes page
         run: php spotify vibes --no-open --output=docs/vibes.html
 
-      - name: Create vibes update PR
-        uses: peter-evans/create-pull-request@v7
+      # Idempotently switches the Pages source to "GitHub Actions" if it isn't
+      # already — no manual repo-settings toggle required.
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
         with:
-          branch: chore/update-vibes-page
-          delete-branch: true
-          title: "docs: update vibes page"
-          commit-message: |
-            docs: update vibes page
+          enablement: true
 
-            🎵 Now playing: Rick Astley - Never Gonna Give You Up
-            💿 Album: Whenever You Need Somebody
-            🔗 Track: https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC
-          body: |
-            Automated vibes page regeneration.
+      # Publish the whole docs/ tree (index, commands, mcp, style + the freshly
+      # generated vibes.html) so every existing page is preserved.
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
 
-            - Regenerated `docs/vibes.html` from latest commit metadata
-            - Opened by GitHub Actions instead of pushing directly to protected `master`
-          add-paths: |
-            docs/vibes.html
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Replaces the create-pull-request vibes flow with a direct GitHub Pages deploy.

**Why:** PRs opened by the Actions token can't trigger the required-checks workflows (anti-recursion safeguard), so the old `chore/update-vibes-page` PRs (e.g. #139) were permanently blocked by branch protection. This regenerates `docs/vibes.html` and deploys the whole `docs/` tree straight to Pages on each master push — page stays current, no commit to protected master, no un-mergeable PRs. `actions/configure-pages` flips the Pages source to GitHub Actions automatically.

🎵 https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC