### PR TITLE
feat: add `wrapped` — Spotify-Wrapped for your commit soundtrack

### DIFF
--- a/app/Commands/VibesCommand.php
+++ b/app/Commands/VibesCommand.php
@@ -4,6 +4,7 @@ namespace App\Commands;
 
 use App\Commands\Concerns\RequiresSpotifyConfig;
 use App\Services\SpotifyDiscoveryService;
+use App\Support\CommitSoundtrack;
 use Illuminate\Support\Facades\Process;
 use LaravelZero\Framework\Commands\Command;
 
@@ -23,10 +24,10 @@ class VibesCommand extends Command
 
     protected $description = 'Generate a page showing commits grouped by the song playing when they were written';
 
-    public function handle(SpotifyDiscoveryService $discovery): int
+    public function handle(SpotifyDiscoveryService $discovery, CommitSoundtrack $soundtrack): int
     {
         $commits = spin(
-            fn (): array => $this->parseGitLog(),
+            fn (): array => $soundtrack->commits(),
             'Parsing git history...'
         );
 
@@ -36,7 +37,7 @@ class VibesCommand extends Command
             return self::SUCCESS;
         }
 
-        $grouped = $this->groupByTrack($commits);
+        $grouped = $soundtrack->groupByTrack($commits);
 
         // Fetch track metadata from Spotify API (album art, names)
         $trackIds = array_column($grouped, 'track_id');
@@ -104,65 +105,6 @@ class VibesCommand extends Command
         }
 
         return self::SUCCESS;
-    }
-
-    private function parseGitLog(): array
-    {
-        $result = Process::run('git log --all --no-merges --format="COMMIT_START%n%H%n%an%n%ai%n%s%n%B%nCOMMIT_END"');
-
-        if (! $result->successful()) {
-            return [];
-        }
-
-        $output = $result->output();
-        $commits = [];
-
-        preg_match_all('/COMMIT_START\n(.+?)\nCOMMIT_END/s', $output, $matches);
-
-        foreach ($matches[1] as $block) {
-            $lines = explode("\n", $block, 5);
-            if (count($lines) < 5) {
-                continue;
-            }
-
-            [$hash, $author, $date, $subject, $body] = $lines;
-
-            $fullMessage = $subject."\n".$body;
-            if (preg_match('#https://open\.spotify\.com/track/([A-Za-z0-9]+)#', $fullMessage, $urlMatch)) {
-                $commits[] = [
-                    'hash' => trim($hash),
-                    'short' => substr(trim($hash), 0, 7),
-                    'author' => trim($author),
-                    'date' => trim($date),
-                    'subject' => trim($subject),
-                    'track_url' => $urlMatch[0],
-                    'track_id' => $urlMatch[1],
-                ];
-            }
-        }
-
-        return $commits;
-    }
-
-    private function groupByTrack(array $commits): array
-    {
-        $groups = [];
-
-        foreach ($commits as $commit) {
-            $trackId = $commit['track_id'];
-            if (! isset($groups[$trackId])) {
-                $groups[$trackId] = [
-                    'track_id' => $trackId,
-                    'track_url' => $commit['track_url'],
-                    'commits' => [],
-                ];
-            }
-            $groups[$trackId]['commits'][] = $commit;
-        }
-
-        usort($groups, fn (array $a, array $b): int => count($b['commits']) <=> count($a['commits']));
-
-        return $groups;
     }
 
     private function syncPlaylist(SpotifyDiscoveryService $discovery, array $groups): ?string

--- a/app/Commands/WrappedCommand.php
+++ b/app/Commands/WrappedCommand.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\Commands;
+
+use App\Services\SpotifyDiscoveryService;
+use App\Support\CommitSoundtrack;
+use LaravelZero\Framework\Commands\Command;
+
+use function Laravel\Prompts\spin;
+
+class WrappedCommand extends Command
+{
+    protected $signature = 'wrapped
+                            {--json : Output the raw stats as JSON instead of the card}
+                            {--no-enrich : Skip the Spotify oEmbed lookup for missing track names}';
+
+    protected $description = 'Your codebase, Spotify-Wrapped style: top tracks, moods and stats from the commit soundtrack';
+
+    /** Inner width (columns) of the rendered card, between the side borders. */
+    private const WIDTH = 48;
+
+    public function handle(SpotifyDiscoveryService $discovery, CommitSoundtrack $soundtrack): int
+    {
+        $commits = $soundtrack->commits();
+
+        if ($commits === []) {
+            $this->components->info('No commits with Spotify track URLs found yet — go write some code to music.');
+
+            return self::SUCCESS;
+        }
+
+        $stats = $soundtrack->stats($commits);
+
+        if (! $this->option('no-enrich')) {
+            $stats['top_tracks'] = $this->enrichNames($discovery, $stats['top_tracks']);
+        }
+
+        if ($this->option('json')) {
+            $this->line((string) json_encode($stats, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+            return self::SUCCESS;
+        }
+
+        foreach ($this->buildCard($stats) as $line) {
+            $this->line($line);
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Fill in track names that the commit messages didn't carry, via Spotify
+     * oEmbed (no auth). Best-effort: any failure leaves the existing value.
+     *
+     * @param  list<array{track_id:string,name:?string,artist:?string,count:int}>  $topTracks
+     * @return list<array{track_id:string,name:?string,artist:?string,count:int}>
+     */
+    private function enrichNames(SpotifyDiscoveryService $discovery, array $topTracks): array
+    {
+        $missing = array_values(array_unique(array_map(
+            fn (array $t): string => $t['track_id'],
+            array_filter($topTracks, fn (array $t): bool => $t['name'] === null || $t['name'] === ''),
+        )));
+
+        if ($missing === []) {
+            return $topTracks;
+        }
+
+        $meta = spin(
+            fn (): array => $this->safeOEmbed($discovery, $missing),
+            'Looking up track names…',
+        );
+
+        foreach ($topTracks as &$track) {
+            if (($track['name'] === null || $track['name'] === '') && isset($meta[$track['track_id']])) {
+                $track['name'] = $meta[$track['track_id']]['name'] ?? $track['name'];
+                $track['artist'] ??= $meta[$track['track_id']]['artist'] ?? null;
+            }
+        }
+        unset($track);
+
+        return $topTracks;
+    }
+
+    /**
+     * @param  list<string>  $ids
+     * @return array<string,array{name?:string,artist?:string}>
+     */
+    private function safeOEmbed(SpotifyDiscoveryService $discovery, array $ids): array
+    {
+        try {
+            return $discovery->getTracksViaOEmbed($ids);
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * Render the wrapped card as a list of aligned lines. Pure (stats in, lines
+     * out) so the layout is unit-testable and the borders provably line up.
+     *
+     * @param  array<string,mixed>  $stats
+     * @return list<string>
+     */
+    public function buildCard(array $stats): array
+    {
+        $w = self::WIDTH;
+        $lines = [];
+
+        // Title baked into the top border.
+        $title = ' THE·SHIT / MUSIC — WRAPPED ';
+        $fill = $w - $this->width($title);
+        $lines[] = '╭'.$title.str_repeat('─', max(0, $fill)).'╮';
+
+        $row = fn (string $content = '') => '│'.$this->pad($content, $w).'│';
+
+        $lines[] = $row();
+        $lines[] = $row(sprintf('  %4d   commits set to music', $stats['total_commits']));
+        $lines[] = $row(sprintf('  %4d   unique tracks', $stats['total_tracks']));
+        $lines[] = $row();
+
+        if ($stats['top_tracks'] !== []) {
+            $lines[] = $row('  TOP TRACKS');
+            $rank = 0;
+            foreach ($stats['top_tracks'] as $track) {
+                $rank++;
+                if ($rank > 3) {
+                    break;
+                }
+                $name = ($track['name'] ?? null) ?: substr($track['track_id'], 0, 12);
+                // Reserve space for "  N  " prefix and "  ×NN" suffix.
+                $count = sprintf('×%3d', $track['count']);
+                $label = sprintf('  %d  %s', $rank, $name);
+                $label = $this->truncate($label, $w - $this->width($count) - 3);
+                $lines[] = $row($this->pad($label, $w - $this->width($count) - 3).'   '.$count);
+            }
+            $lines[] = $row();
+        }
+
+        if ($stats['top_artist'] !== null) {
+            $lines[] = $row(sprintf('  Top artist   %s (%d)', $stats['top_artist']['name'], $stats['top_artist']['count']));
+        }
+
+        if ($stats['dominant_type'] !== null) {
+            [$emoji, $word] = $this->vibe($stats['dominant_type']);
+            $count = $stats['type_breakdown'][$stats['dominant_type']] ?? 0;
+            $lines[] = $row(sprintf('  Top vibe     %s %s (%s ×%d)', $emoji, $word, $stats['dominant_type'], $count));
+        }
+
+        if ($stats['first_date'] !== null && $stats['last_date'] !== null) {
+            $from = date('M Y', strtotime((string) $stats['first_date']));
+            $to = date('M Y', strtotime((string) $stats['last_date']));
+            $span = $from === $to ? $from : "{$from} → {$to}";
+            $lines[] = $row('  '.$span);
+        }
+
+        $lines[] = $row();
+        $lines[] = '╰'.str_repeat('─', $w).'╯';
+
+        return $lines;
+    }
+
+    /**
+     * A human "vibe" for a conventional-commit type.
+     *
+     * @return array{0:string,1:string} [emoji, word]
+     */
+    private function vibe(string $type): array
+    {
+        return match ($type) {
+            'feat' => ['🚀', 'shipping'],
+            'fix' => ['🔧', 'firefighting'],
+            'docs' => ['📝', 'documenting'],
+            'test' => ['🧪', 'testing'],
+            'refactor' => ['🧹', 'tidying'],
+            'chore' => ['📦', 'maintaining'],
+            'ci' => ['🤖', 'automating'],
+            'perf' => ['⚡', 'optimizing'],
+            'style' => ['🎨', 'polishing'],
+            'build' => ['🏗', 'building'],
+            default => ['🎵', 'vibing'],
+        };
+    }
+
+    /** Right-pad to a display width, truncating with an ellipsis if too long. */
+    private function pad(string $s, int $width): string
+    {
+        $s = $this->truncate($s, $width);
+        $gap = $width - $this->width($s);
+
+        return $s.str_repeat(' ', max(0, $gap));
+    }
+
+    /** Truncate to a display width (mb-aware), appending '…' when clipped. */
+    private function truncate(string $s, int $width): string
+    {
+        if ($this->width($s) <= $width) {
+            return $s;
+        }
+
+        return rtrim(mb_strimwidth($s, 0, max(1, $width - 1), '', 'UTF-8')).'…';
+    }
+
+    private function width(string $s): int
+    {
+        return mb_strwidth($s, 'UTF-8');
+    }
+}

--- a/app/Support/CommitSoundtrack.php
+++ b/app/Support/CommitSoundtrack.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Process;
+
+/**
+ * The single source of truth for "which song was playing when this code was
+ * committed". Reads git history, keeps only commits that carry a Spotify track
+ * URL (the Vibe Check gate guarantees most do), and exposes them grouped by
+ * track plus a few wrapped-style aggregates.
+ *
+ * Deliberately network-free: parsing and stats work entirely off the commit
+ * messages, so this class is fully unit-testable by injecting raw `git log`
+ * output. Track names are best-effort from the "🎵 Now playing: Artist - Title"
+ * line commits already include; callers that want guaranteed names enrich the
+ * track ids via Spotify oEmbed/API afterwards.
+ */
+class CommitSoundtrack
+{
+    /**
+     * The git-log format used for parsing. Each commit is delimited so a body
+     * spanning multiple lines (where the track URL usually lives) survives.
+     */
+    private const FORMAT = 'COMMIT_START%n%H%n%an%n%ai%n%s%n%B%nCOMMIT_END';
+
+    /**
+     * Parse every commit that carries a Spotify track URL.
+     *
+     * @param  string|null  $rawLog  Inject `git log` output (tests); null shells out.
+     * @return list<array{hash:string,short:string,author:string,date:string,subject:string,type:?string,track_id:string,track_url:string,track_name:?string,track_artist:?string}>
+     */
+    public function commits(?string $rawLog = null): array
+    {
+        $output = $rawLog ?? $this->gitLog();
+        if ($output === '') {
+            return [];
+        }
+
+        preg_match_all('/COMMIT_START\n(.+?)\nCOMMIT_END/s', $output, $matches);
+
+        $commits = [];
+        foreach ($matches[1] as $block) {
+            $lines = explode("\n", $block, 5);
+            if (count($lines) < 5) {
+                continue;
+            }
+
+            [$hash, $author, $date, $subject, $body] = $lines;
+            $fullMessage = $subject."\n".$body;
+
+            if (! preg_match('#https://open\.spotify\.com/track/([A-Za-z0-9]+)#', $fullMessage, $urlMatch)) {
+                continue;
+            }
+
+            [$name, $artist] = $this->nowPlaying($fullMessage);
+
+            $commits[] = [
+                'hash' => trim($hash),
+                'short' => substr(trim($hash), 0, 7),
+                'author' => trim($author),
+                'date' => trim($date),
+                'subject' => trim($subject),
+                'type' => $this->conventionalType(trim($subject)),
+                'track_id' => $urlMatch[1],
+                'track_url' => $urlMatch[0],
+                'track_name' => $name,
+                'track_artist' => $artist,
+            ];
+        }
+
+        return $commits;
+    }
+
+    /**
+     * Group commits by track, most-played first. Each group carries the first
+     * resolved name/artist seen for that track.
+     *
+     * @param  list<array<string,mixed>>  $commits
+     * @return list<array{track_id:string,track_url:string,name:?string,artist:?string,commits:list<array<string,mixed>>}>
+     */
+    public function groupByTrack(array $commits): array
+    {
+        $groups = [];
+
+        foreach ($commits as $commit) {
+            $id = $commit['track_id'];
+            if (! isset($groups[$id])) {
+                $groups[$id] = [
+                    'track_id' => $id,
+                    'track_url' => $commit['track_url'],
+                    'name' => $commit['track_name'],
+                    'artist' => $commit['track_artist'],
+                    'commits' => [],
+                ];
+            }
+
+            // Backfill name/artist from any commit that has it.
+            $groups[$id]['name'] ??= $commit['track_name'];
+            $groups[$id]['artist'] ??= $commit['track_artist'];
+            $groups[$id]['commits'][] = $commit;
+        }
+
+        $groups = array_values($groups);
+        usort($groups, fn (array $a, array $b): int => count($b['commits']) <=> count($a['commits']));
+
+        return $groups;
+    }
+
+    /**
+     * Wrapped-style aggregates over the parsed commits.
+     *
+     * @param  list<array<string,mixed>>  $commits
+     * @return array{total_commits:int,total_tracks:int,top_tracks:list<array{track_id:string,name:?string,artist:?string,count:int}>,top_artist:?array{name:string,count:int},type_breakdown:array<string,int>,dominant_type:?string,first_date:?string,last_date:?string}
+     */
+    public function stats(array $commits): array
+    {
+        $groups = $this->groupByTrack($commits);
+
+        $topTracks = [];
+        foreach (array_slice($groups, 0, 5) as $group) {
+            $topTracks[] = [
+                'track_id' => $group['track_id'],
+                'name' => $group['name'],
+                'artist' => $group['artist'],
+                'count' => count($group['commits']),
+            ];
+        }
+
+        // Top artist (only counts commits where the artist is known).
+        $artistCounts = [];
+        foreach ($commits as $commit) {
+            $artist = $commit['track_artist'];
+            if ($artist !== null && $artist !== '') {
+                $artistCounts[$artist] = ($artistCounts[$artist] ?? 0) + 1;
+            }
+        }
+        arsort($artistCounts);
+        $topArtist = $artistCounts === []
+            ? null
+            : ['name' => (string) array_key_first($artistCounts), 'count' => reset($artistCounts)];
+
+        // Conventional-commit type breakdown, most frequent first.
+        $typeBreakdown = [];
+        foreach ($commits as $commit) {
+            $type = $commit['type'] ?? 'other';
+            $typeBreakdown[$type] = ($typeBreakdown[$type] ?? 0) + 1;
+        }
+        arsort($typeBreakdown);
+
+        $dates = array_filter(array_column($commits, 'date'));
+        sort($dates);
+
+        return [
+            'total_commits' => count($commits),
+            'total_tracks' => count($groups),
+            'top_tracks' => $topTracks,
+            'top_artist' => $topArtist,
+            'type_breakdown' => $typeBreakdown,
+            'dominant_type' => $typeBreakdown === [] ? null : (string) array_key_first($typeBreakdown),
+            'first_date' => $dates === [] ? null : reset($dates),
+            'last_date' => $dates === [] ? null : end($dates),
+        ];
+    }
+
+    /**
+     * Pull "Artist - Title" out of the "🎵 Now playing:" line commits embed.
+     * Splits on the first " - " so titles containing a dash survive.
+     *
+     * @return array{0:?string,1:?string} [name, artist]
+     */
+    private function nowPlaying(string $message): array
+    {
+        if (! preg_match('/Now playing:\s*(.+)/u', $message, $m)) {
+            return [null, null];
+        }
+
+        $line = trim($m[1]);
+        $parts = explode(' - ', $line, 2);
+        if (count($parts) === 2) {
+            return [trim($parts[1]), trim($parts[0])];
+        }
+
+        return [$line, null];
+    }
+
+    /**
+     * The conventional-commit type prefix (feat, fix, …) or null.
+     */
+    private function conventionalType(string $subject): ?string
+    {
+        if (preg_match('/^(feat|fix|test|ci|refactor|docs|chore|style|perf|build)(?:\([^)]+\))?!?:/', $subject, $m)) {
+            return $m[1];
+        }
+
+        return null;
+    }
+
+    private function gitLog(): string
+    {
+        $result = Process::run('git log --all --no-merges --format="'.self::FORMAT.'"');
+
+        return $result->successful() ? $result->output() : '';
+    }
+}

--- a/tests/Feature/WrappedCommandTest.php
+++ b/tests/Feature/WrappedCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Commands\WrappedCommand;
+use App\Support\CommitSoundtrack;
+
+function wrappedStats(array $overrides = []): array
+{
+    return array_merge([
+        'total_commits' => 137,
+        'total_tracks' => 53,
+        'top_tracks' => [
+            ['track_id' => 'a', 'name' => 'Never Gonna Give You Up', 'artist' => 'Rick Astley', 'count' => 26],
+            ['track_id' => 'b', 'name' => 'Blinding Lights', 'artist' => 'The Weeknd', 'count' => 11],
+            ['track_id' => 'c', 'name' => 'Bohemian Rhapsody', 'artist' => 'Queen', 'count' => 8],
+        ],
+        'top_artist' => ['name' => 'Rick Astley', 'count' => 31],
+        'type_breakdown' => ['feat' => 54, 'fix' => 30],
+        'dominant_type' => 'feat',
+        'first_date' => '2026-01-01 00:00:00 -0700',
+        'last_date' => '2026-06-01 00:00:00 -0700',
+    ], $overrides);
+}
+
+it('renders a card whose borders all line up', function (): void {
+    $lines = $this->app->make(WrappedCommand::class)->buildCard(wrappedStats());
+
+    // Every line — top border, side rows, bottom border — must be the same
+    // display width, or the box looks broken in the terminal.
+    $widths = array_map(fn (string $l): int => mb_strwidth($l, 'UTF-8'), $lines);
+    expect(array_unique($widths))->toHaveCount(1);
+});
+
+it('shows the headline stats and top tracks on the card', function (): void {
+    $card = implode("\n", $this->app->make(WrappedCommand::class)->buildCard(wrappedStats()));
+
+    expect($card)
+        ->toContain('WRAPPED')
+        ->toContain('137')
+        ->toContain('53')
+        ->toContain('Never Gonna Give You Up')
+        ->toContain('Rick Astley')
+        ->toContain('shipping'); // feat → 🚀 shipping
+});
+
+it('truncates an over-long track name but keeps the box aligned', function (): void {
+    $stats = wrappedStats([
+        'top_tracks' => [
+            ['track_id' => 'a', 'name' => str_repeat('Supercalifragilistic ', 6), 'artist' => 'X', 'count' => 9],
+        ],
+    ]);
+    $lines = $this->app->make(WrappedCommand::class)->buildCard($stats);
+    $card = implode("\n", $lines);
+
+    expect($card)->toContain('…');
+    expect(array_unique(array_map(fn (string $l): int => mb_strwidth($l, 'UTF-8'), $lines)))->toHaveCount(1);
+});
+
+it('falls back to the track id when a name is unknown', function (): void {
+    $stats = wrappedStats([
+        'top_tracks' => [['track_id' => '4uLU6hMCjMI7', 'name' => null, 'artist' => null, 'count' => 3]],
+    ]);
+    $card = implode("\n", $this->app->make(WrappedCommand::class)->buildCard($stats));
+
+    expect($card)->toContain('4uLU6hMCjMI7');
+});
+
+it('outputs raw stats as json with --json', function (): void {
+    $fake = Mockery::mock(CommitSoundtrack::class)->makePartial();
+    $fake->shouldReceive('commits')->andReturn([
+        ['hash' => 'a1', 'short' => 'a1', 'author' => 'J', 'date' => '2026-01-01 00:00:00 -0700',
+            'subject' => 'feat: x', 'type' => 'feat', 'track_id' => 'T1', 'track_url' => 'u',
+            'track_name' => 'Song One', 'track_artist' => 'Artist'],
+        ['hash' => 'b2', 'short' => 'b2', 'author' => 'J', 'date' => '2026-02-01 00:00:00 -0700',
+            'subject' => 'fix: y', 'type' => 'fix', 'track_id' => 'T1', 'track_url' => 'u',
+            'track_name' => 'Song One', 'track_artist' => 'Artist'],
+    ]);
+    $this->app->instance(CommitSoundtrack::class, $fake);
+
+    $code = Illuminate\Support\Facades\Artisan::call('wrapped', ['--json' => true, '--no-enrich' => true]);
+    $output = Illuminate\Support\Facades\Artisan::output();
+
+    expect($code)->toBe(0);
+    expect($output)
+        ->toContain('"total_commits": 2')
+        ->toContain('"total_tracks": 1');
+});
+
+it('handles a repo with no soundtracked commits', function (): void {
+    $fake = Mockery::mock(CommitSoundtrack::class)->makePartial();
+    $fake->shouldReceive('commits')->andReturn([]);
+    $this->app->instance(CommitSoundtrack::class, $fake);
+
+    $this->artisan('wrapped')
+        ->expectsOutputToContain('No commits with Spotify track URLs')
+        ->assertExitCode(0);
+});

--- a/tests/Unit/Support/CommitSoundtrackTest.php
+++ b/tests/Unit/Support/CommitSoundtrackTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Support\CommitSoundtrack;
+
+/**
+ * Raw `git log` output in the exact format CommitSoundtrack parses
+ * (COMMIT_START / hash / author / date / subject / %B / COMMIT_END).
+ */
+function fakeGitLog(): string
+{
+    $blocks = [
+        // Two commits on the same track (Rick Astley), with the Now-playing line.
+        ['aaaaaaa111', 'Jordan', '2026-01-05 10:00:00 -0700', 'feat: add player',
+            "feat: add player\n\n🎵 Now playing: Rick Astley - Never Gonna Give You Up\n🔗 Track: https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC"],
+        ['bbbbbbb222', 'Jordan', '2026-02-10 09:00:00 -0700', 'fix: player crash',
+            "fix: player crash\n\n🎵 Now playing: Rick Astley - Never Gonna Give You Up\nhttps://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC"],
+        // A track whose TITLE contains a dash — must survive the split.
+        ['ccccccc333', 'Jordan', '2026-03-01 12:00:00 -0700', 'feat: queue editor',
+            "feat: queue editor\n\n🎵 Now playing: Daft Punk - Harder, Better - Faster\nhttps://open.spotify.com/track/2ZZZZZZZZZZZZZZZZZZZZ1"],
+        // A track with NO Now-playing line — name stays null (enriched later).
+        ['ddddddd444', 'Jordan', '2026-03-15 12:00:00 -0700', 'docs: readme',
+            "docs: readme\n\nhttps://open.spotify.com/track/3YYYYYYYYYYYYYYYYYYYY2"],
+        // No track URL at all — must be skipped entirely.
+        ['eeeeeee555', 'Jordan', '2026-04-01 12:00:00 -0700', 'chore: bump deps',
+            "chore: bump deps\n\nnothing playing"],
+    ];
+
+    $out = '';
+    foreach ($blocks as [$hash, $author, $date, $subject, $body]) {
+        $out .= "COMMIT_START\n{$hash}\n{$author}\n{$date}\n{$subject}\n{$body}\nCOMMIT_END\n";
+    }
+
+    return $out;
+}
+
+it('parses only commits that carry a spotify track url', function (): void {
+    $commits = (new CommitSoundtrack)->commits(fakeGitLog());
+
+    expect($commits)->toHaveCount(4); // the no-URL chore commit is skipped
+    expect(array_column($commits, 'subject'))->not->toContain('chore: bump deps');
+});
+
+it('extracts name and artist from the now-playing line', function (): void {
+    $commits = (new CommitSoundtrack)->commits(fakeGitLog());
+
+    expect($commits[0]['track_name'])->toBe('Never Gonna Give You Up');
+    expect($commits[0]['track_artist'])->toBe('Rick Astley');
+    expect($commits[0]['type'])->toBe('feat');
+});
+
+it('keeps a dash inside the track title when splitting artist - title', function (): void {
+    $commits = (new CommitSoundtrack)->commits(fakeGitLog());
+    $daft = collect($commits)->firstWhere('track_artist', 'Daft Punk');
+
+    expect($daft['track_name'])->toBe('Harder, Better - Faster');
+});
+
+it('leaves name null when no now-playing line is present', function (): void {
+    $commits = (new CommitSoundtrack)->commits(fakeGitLog());
+    $docs = collect($commits)->firstWhere('subject', 'docs: readme');
+
+    expect($docs['track_name'])->toBeNull();
+});
+
+it('groups by track, most played first', function (): void {
+    $soundtrack = new CommitSoundtrack;
+    $groups = $soundtrack->groupByTrack($soundtrack->commits(fakeGitLog()));
+
+    expect($groups)->toHaveCount(3);
+    expect(count($groups[0]['commits']))->toBe(2); // Rick Astley leads with 2
+    expect($groups[0]['name'])->toBe('Never Gonna Give You Up');
+});
+
+it('computes wrapped stats', function (): void {
+    $soundtrack = new CommitSoundtrack;
+    $stats = $soundtrack->stats($soundtrack->commits(fakeGitLog()));
+
+    expect($stats['total_commits'])->toBe(4);
+    expect($stats['total_tracks'])->toBe(3);
+    expect($stats['top_tracks'][0]['count'])->toBe(2);
+    expect($stats['top_artist'])->toBe(['name' => 'Rick Astley', 'count' => 2]);
+    // feat appears twice → dominant.
+    expect($stats['dominant_type'])->toBe('feat');
+    expect($stats['type_breakdown']['feat'])->toBe(2);
+    expect($stats['first_date'])->toContain('2026-01-05');
+    expect($stats['last_date'])->toContain('2026-03-15');
+});
+
+it('returns nothing for empty history', function (): void {
+    expect((new CommitSoundtrack)->commits(''))->toBe([]);
+    expect((new CommitSoundtrack)->stats([]))->toMatchArray([
+        'total_commits' => 0,
+        'total_tracks' => 0,
+        'top_artist' => null,
+        'dominant_type' => null,
+    ]);
+});


### PR DESCRIPTION
A `spotify wrapped` command: top tracks, top artist, commit-type "vibe" and totals, rendered as an aligned terminal card from the per-commit Spotify track URLs the Vibe Check already enforces.

- New `App\Support\CommitSoundtrack` (pure, network-free, unit-tested) is now the single source of truth for parsing the commit soundtrack; `VibesCommand` was refactored to delegate to it (removing its inline duplicate parser).
- Track names come from the commit "Now playing" line, with Spotify oEmbed (no auth) filling gaps for the top tracks; `--no-enrich` skips the lookup, `--json` emits raw stats.
- 13 new tests (parse/group/stats + card border-alignment); full suite 689 green, phpstan + pint clean.

🎵 https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC