### PR TITLE
fix: respect Spotify 429s (circuit breaker) + daemon health detection

### DIFF
--- a/app/Commands/DaemonCommand.php
+++ b/app/Commands/DaemonCommand.php
@@ -24,6 +24,13 @@ class DaemonCommand extends Command
 
     private const LEGACY_LAUNCH_AGENT_LABEL = 'com.spotify-cli.spotifyd';
 
+    /**
+     * Health scans only this recent window of spotifyd.log — the log is never
+     * rotated outside --heal, so it accumulates weeks of history and stale
+     * errors that say nothing about the daemon's health right now.
+     */
+    private const LOG_TAIL_LINES = 500;
+
     private string $pidFile;
 
     private string $configDir;
@@ -94,7 +101,7 @@ class DaemonCommand extends Command
         $configFile = $this->configDir.'/spotifyd.conf';
         $orphanPid = trim((string) shell_exec("pgrep -f 'spotifyd.*{$configFile}' 2>/dev/null | head -1"));
         $orphanComm = $orphanPid !== '' && $orphanPid !== '0' ? trim((string) shell_exec("ps -p {$orphanPid} -o comm= 2>/dev/null")) : '';
-        if ($orphanPid && $orphanComm === 'spotifyd') {
+        if ($orphanPid && self::isSpotifydComm($orphanComm)) {
             warning("Found orphaned spotifyd (PID: {$orphanPid}) — adopting it");
             $this->savePid((int) $orphanPid);
             info('✅ Daemon adopted');
@@ -393,13 +400,27 @@ class DaemonCommand extends Command
 
         // Verify the PID is actually spotifyd, not a recycled process
         $comm = trim((string) shell_exec("ps -p {$pid} -o comm= 2>/dev/null"));
-        if ($comm !== 'spotifyd') {
+        if (! self::isSpotifydComm($comm)) {
             @unlink($this->pidFile);
 
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Whether a `ps -o comm=` value names a spotifyd binary.
+     *
+     * WHY not `$comm === 'spotifyd'`: on macOS `comm` is the FULL PATH
+     * (/Users/x/.local/bin/spotifyd-rodio), and our preferred binary is named
+     * `spotifyd-rodio` — so an exact match was ALWAYS false, health reported
+     * the daemon dead forever, and the --heal loop never engaged. Public static
+     * + pure so the comparison itself is unit-testable.
+     */
+    public static function isSpotifydComm(string $comm): bool
+    {
+        return str_starts_with(basename(trim($comm)), 'spotifyd');
     }
 
     private function getDaemonPid(): ?int
@@ -409,7 +430,7 @@ class DaemonCommand extends Command
             $pid = (int) file_get_contents($this->pidFile);
             if ($pid > 0 && @posix_kill($pid, 0)) {
                 $comm = trim((string) shell_exec("ps -p {$pid} -o comm= 2>/dev/null"));
-                if ($comm === 'spotifyd') {
+                if (self::isSpotifydComm($comm)) {
                     return $pid;
                 }
             }
@@ -420,7 +441,7 @@ class DaemonCommand extends Command
         $pid = trim((string) shell_exec("pgrep -f 'spotifyd.*{$configFile}' 2>/dev/null | head -1"));
         if ($pid !== '' && $pid !== '0') {
             $comm = trim((string) shell_exec("ps -p {$pid} -o comm= 2>/dev/null"));
-            if ($comm === 'spotifyd') {
+            if (self::isSpotifydComm($comm)) {
                 return (int) $pid;
             }
         }
@@ -635,8 +656,21 @@ XML;
             'pid' => $pid,
             'errors' => $errors,
             'cache_size_mb' => $cacheSize,
-            'log_lines' => file_exists($logFile) ? count(file($logFile)) : 0,
+            'log_lines' => $this->countLogLines($logFile),
         ];
+    }
+
+    /**
+     * Count log lines without loading the file into memory — count(file())
+     * materialised every line of a multi-million-line log just to count them.
+     */
+    private function countLogLines(string $logFile): int
+    {
+        if (! file_exists($logFile)) {
+            return 0;
+        }
+
+        return (int) trim((string) shell_exec('wc -l < '.escapeshellarg($logFile).' 2>/dev/null'));
     }
 
     private function heal(array $diagnosis): int
@@ -761,9 +795,13 @@ XML;
             'failed to put connect state' => 0,
         ];
 
-        // Read last 500 lines to avoid parsing massive logs
-        $lines = file($logFile);
-        $lines = array_slice($lines, -500);
+        // Scan ONLY a recent tail window. file() loaded the ENTIRE log into
+        // memory first (weeks of history, millions of lines) just to slice the
+        // end off — and any error counted from months-old lines is meaningless
+        // for "is the daemon healthy right now". tail streams the last lines
+        // without reading the rest.
+        $tail = (string) shell_exec('tail -n '.self::LOG_TAIL_LINES.' '.escapeshellarg($logFile).' 2>/dev/null');
+        $lines = $tail === '' ? [] : explode("\n", $tail);
 
         foreach ($lines as $line) {
             foreach ($patterns as $pattern => $count) {

--- a/app/Commands/PremiumPlayerCommand.php
+++ b/app/Commands/PremiumPlayerCommand.php
@@ -12,6 +12,7 @@ use App\Player\PlayerTheme;
 use App\Player\PlayerViewModel;
 use App\Services\SpotifyDiscoveryService;
 use App\Services\SpotifyPlayerService;
+use App\Support\SpotifyRateLimit;
 use LaravelZero\Framework\Commands\Command;
 use PhpTui\Term\Actions;
 use PhpTui\Term\Event\CharKeyEvent;
@@ -210,6 +211,10 @@ class PremiumPlayerCommand extends Command
                     // artist_id we need to resolve mood.
                     $payload = $this->safePlayback($player);
                     $vm = PlayerViewModel::fromPlayback($payload);
+                    // Stamp the 429 breaker state each refresh: when Spotify is
+                    // rate-limiting us every poll comes back empty, and the empty
+                    // panel must say so instead of "Nothing playing right now".
+                    $vm->rateLimitedUntil = SpotifyRateLimit::resumesAt();
                     $lastFetch = $now;
 
                     // Resolve mood ONLY when the track changes (cheap key compare),
@@ -499,7 +504,9 @@ class PremiumPlayerCommand extends Command
             return $renderer->lyricsOverlay($lyrics['track'], $lyrics['lines'], $lyrics['scroll']);
         }
 
-        return ($vm !== null && $vm->hasPlayback) ? $renderer->nowPlaying($vm) : $renderer->empty();
+        // The empty state carries the rate-limit notice (when the breaker is
+        // open) so a throttled player reads honestly instead of "Nothing playing".
+        return ($vm !== null && $vm->hasPlayback) ? $renderer->nowPlaying($vm) : $renderer->empty($vm?->rateLimitNotice());
     }
 
     /**

--- a/app/Player/PlayerRenderer.php
+++ b/app/Player/PlayerRenderer.php
@@ -278,16 +278,26 @@ final class PlayerRenderer
     /**
      * The calm nothing-playing panel. Same mood frame, centred guidance text —
      * so an idle player still feels like part of the surface, not an error.
+     *
+     * When a $notice is given (the VM's rate-limit line) it REPLACES the default
+     * "Nothing playing right now": while Spotify is 429-ing us every poll fails,
+     * so claiming nothing is playing would be a lie — the honest state is "we're
+     * rate-limited, back at ~HH:MM". php-tui's centred alignment owns the
+     * padding, so the box stays aligned for any notice length.
      */
-    public function empty(): Widget
+    public function empty(?string $notice = null): Widget
     {
         $theme = $this->theme;
 
+        $hint = $notice === null
+            ? 'Press / to search, or start playback on Spotify'
+            : 'Polling is paused so the limit can reset';
+
         $body = ParagraphWidget::fromLines(
             Line::fromString(''),
-            Line::fromSpans(Span::styled('Nothing playing right now', $theme->text())),
+            Line::fromSpans(Span::styled($notice ?? 'Nothing playing right now', $theme->text())),
             Line::fromString(''),
-            Line::fromSpans(Span::styled('Press / to search, or start playback on Spotify', $theme->dim())),
+            Line::fromSpans(Span::styled($hint, $theme->dim())),
         )->alignment(HorizontalAlignment::Center);
 
         return BlockWidget::default()

--- a/app/Player/PlayerViewModel.php
+++ b/app/Player/PlayerViewModel.php
@@ -46,7 +46,28 @@ final class PlayerViewModel
         // PremiumPlayerCommand) and leaves it null otherwise. Mutable + trailing with a
         // safe default so fromPlayback() stays I/O-free and positional ctors keep working.
         public ?string $upNext = null,
+        // Unix timestamp when Spotify's 429 rate limit lifts, null when not limited.
+        // NOT derivable from the playback payload — the loop reads it from the
+        // SpotifyRateLimit breaker each refresh (see PremiumPlayerCommand). Drives the
+        // honest rate-limited empty state instead of a misleading "Nothing playing".
+        // Mutable + trailing with a safe default, same contract as mood/upNext.
+        public ?int $rateLimitedUntil = null,
     ) {}
+
+    /**
+     * Honest empty-state line while Spotify is rate-limiting us, or null when
+     * the breaker is closed. Lives on the VM (not the renderer) so the wording
+     * and the HH:MM formatting are unit-testable pure PHP — the renderer just
+     * swaps it in for "Nothing playing right now".
+     */
+    public function rateLimitNotice(): ?string
+    {
+        if ($this->rateLimitedUntil === null) {
+            return null;
+        }
+
+        return '⏳ Spotify is rate-limiting us — resumes ~'.date('H:i', $this->rateLimitedUntil);
+    }
 
     /**
      * Map a SpotifyPlayerService::getCurrentPlayback() payload into a view model.

--- a/app/Services/SpotifyDiscoveryService.php
+++ b/app/Services/SpotifyDiscoveryService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Support\SpotifyRateLimit;
 use Illuminate\Support\Facades\Http;
 
 class SpotifyDiscoveryService
@@ -22,14 +23,14 @@ class SpotifyDiscoveryService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->get($this->baseUri.'search', [
                 'q' => $query,
                 'type' => $type,
                 'limit' => 1,
-            ]);
+            ]));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
             if (isset($data['tracks']['items'][0])) {
                 $track = $data['tracks']['items'][0];
@@ -52,14 +53,14 @@ class SpotifyDiscoveryService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->get($this->baseUri.'search', [
                 'q' => $query,
                 'type' => $type,
                 'limit' => $limit,
-            ]);
+            ]));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
             $results = [];
 
@@ -87,13 +88,13 @@ class SpotifyDiscoveryService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->get($this->baseUri.'me/top/tracks', [
                 'time_range' => $timeRange,
                 'limit' => $limit,
-            ]);
+            ]));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
             $tracks = [];
 
@@ -119,13 +120,13 @@ class SpotifyDiscoveryService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->get($this->baseUri.'me/top/artists', [
                 'time_range' => $timeRange,
                 'limit' => $limit,
-            ]);
+            ]));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
             $artists = [];
 
@@ -150,12 +151,12 @@ class SpotifyDiscoveryService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->get($this->baseUri.'me/player/recently-played', [
                 'limit' => $limit,
-            ]);
+            ]));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
             $tracks = [];
 
@@ -233,10 +234,10 @@ class SpotifyDiscoveryService
             $params[$key] = $value;
         }
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->get($this->baseUri.'recommendations', $params);
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->get($this->baseUri.'recommendations', $params));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
             $tracks = [];
 
@@ -456,12 +457,12 @@ class SpotifyDiscoveryService
             return [];
         }
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->get($this->baseUri.'me/playlists', [
                 'limit' => $limit,
-            ]);
+            ]));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
 
             return $data['items'] ?? [];
@@ -479,10 +480,10 @@ class SpotifyDiscoveryService
             return [];
         }
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->get($this->baseUri."playlists/{$playlistId}/tracks");
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->get($this->baseUri."playlists/{$playlistId}/tracks"));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
 
             return $data['items'] ?? [];
@@ -504,12 +505,12 @@ class SpotifyDiscoveryService
 
         // Spotify allows max 50 IDs per request
         foreach (array_chunk($trackIds, 50) as $chunk) {
-            $response = Http::withToken($this->auth->getAccessToken())
+            $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
                 ->get($this->baseUri.'tracks', [
                     'ids' => implode(',', $chunk),
-                ]);
+                ]));
 
-            if ($response->successful()) {
+            if ($response !== null && $response->successful()) {
                 foreach ($response->json()['tracks'] ?? [] as $track) {
                     if (! $track) {
                         continue;
@@ -606,14 +607,14 @@ class SpotifyDiscoveryService
             return null;
         }
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->post($this->baseUri."users/{$profile['id']}/playlists", [
                 'name' => $name,
                 'description' => $description,
                 'public' => $public,
-            ]);
+            ]));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             return $response->json();
         }
 
@@ -631,19 +632,19 @@ class SpotifyDiscoveryService
         $first = true;
         foreach (array_chunk($trackUris, 100) as $chunk) {
             if ($first) {
-                $response = Http::withToken($this->auth->getAccessToken())
+                $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
                     ->put($this->baseUri."playlists/{$playlistId}/tracks", [
                         'uris' => $chunk,
-                    ]);
+                    ]));
                 $first = false;
             } else {
-                $response = Http::withToken($this->auth->getAccessToken())
+                $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
                     ->post($this->baseUri."playlists/{$playlistId}/tracks", [
                         'uris' => $chunk,
-                    ]);
+                    ]));
             }
 
-            if (! $response->successful()) {
+            if (! $response?->successful()) {
                 return false;
             }
         }
@@ -676,10 +677,10 @@ class SpotifyDiscoveryService
             return false;
         }
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->put($this->baseUri."playlists/{$playlistId}", $details);
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->put($this->baseUri."playlists/{$playlistId}", $details));
 
-        return $response->successful();
+        return $response !== null && $response->successful();
     }
 
     /**
@@ -689,10 +690,10 @@ class SpotifyDiscoveryService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->get($this->baseUri.'me');
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->get($this->baseUri.'me'));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             return $response->json();
         }
 

--- a/app/Services/SpotifyPlayerService.php
+++ b/app/Services/SpotifyPlayerService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Support\SpotifyRateLimit;
 use Exception;
 use Illuminate\Support\Facades\Http;
 
@@ -55,14 +56,14 @@ class SpotifyPlayerService
             }
         }
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->put($this->baseUri.'me/player/play', [
                 'device_id' => $deviceId,
                 'uris' => [$uri],
-            ]);
+            ]));
 
-        if (! $response->successful()) {
-            $error = $response->json();
+        if (! $response?->successful()) {
+            $error = $response?->json();
             throw new \Exception($error['error']['message'] ?? 'Failed to play track');
         }
     }
@@ -93,11 +94,11 @@ class SpotifyPlayerService
 
         $body = $deviceId ? ['device_id' => $deviceId] : [];
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->put($this->baseUri.'me/player/play', $body);
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->put($this->baseUri.'me/player/play', $body));
 
-        if (! $response->successful()) {
-            $error = $response->json();
+        if (! $response?->successful()) {
+            $error = $response?->json();
             throw new \Exception($error['error']['message'] ?? 'Failed to resume playback');
         }
     }
@@ -109,11 +110,11 @@ class SpotifyPlayerService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->put($this->baseUri.'me/player/pause');
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->put($this->baseUri.'me/player/pause'));
 
-        if (! $response->successful()) {
-            $error = $response->json();
+        if (! $response?->successful()) {
+            $error = $response?->json();
             throw new \Exception($error['error']['message'] ?? 'Failed to pause playback');
         }
     }
@@ -128,10 +129,10 @@ class SpotifyPlayerService
         // Clamp volume to 0-100
         $volumePercent = max(0, min(100, $volumePercent));
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->put($this->baseUri.'me/player/volume?volume_percent='.$volumePercent);
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->put($this->baseUri.'me/player/volume?volume_percent='.$volumePercent));
 
-        return $response->successful();
+        return $response !== null && $response->successful();
     }
 
     /**
@@ -141,11 +142,11 @@ class SpotifyPlayerService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->post($this->baseUri.'me/player/next');
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->post($this->baseUri.'me/player/next'));
 
-        if (! $response->successful()) {
-            $error = $response->json();
+        if (! $response?->successful()) {
+            $error = $response?->json();
             throw new \Exception($error['error']['message'] ?? 'Failed to skip track');
         }
     }
@@ -157,11 +158,11 @@ class SpotifyPlayerService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->post($this->baseUri.'me/player/previous');
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->post($this->baseUri.'me/player/previous'));
 
-        if (! $response->successful()) {
-            $error = $response->json();
+        if (! $response?->successful()) {
+            $error = $response?->json();
             throw new \Exception($error['error']['message'] ?? 'Failed to skip to previous');
         }
     }
@@ -173,10 +174,10 @@ class SpotifyPlayerService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->get($this->baseUri.'me/player/devices');
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->get($this->baseUri.'me/player/devices'));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
 
             return $data['devices'] ?? [];
@@ -192,14 +193,14 @@ class SpotifyPlayerService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->put($this->baseUri.'me/player', [
                 'device_ids' => [$deviceId],
                 'play' => $play,
-            ]);
+            ]));
 
-        if (! $response->successful()) {
-            $error = $response->json();
+        if (! $response?->successful()) {
+            $error = $response?->json();
             throw new Exception($error['error']['message'] ?? 'Failed to transfer playback');
         }
     }
@@ -236,14 +237,14 @@ class SpotifyPlayerService
         }
 
         // The queue endpoint expects uri as a query parameter, not in the body
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->post($this->baseUri.'me/player/queue?'.http_build_query([
                 'uri' => $uri,
                 'device_id' => $device['id'],
-            ]));
+            ])));
 
-        if (! $response->successful()) {
-            $error = $response->json();
+        if (! $response?->successful()) {
+            $error = $response?->json();
             throw new \Exception($error['error']['message'] ?? 'Failed to add to queue');
         }
     }
@@ -257,10 +258,10 @@ class SpotifyPlayerService
             return [];
         }
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->get($this->baseUri.'me/player/queue');
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->get($this->baseUri.'me/player/queue'));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
 
             return [
@@ -279,11 +280,11 @@ class SpotifyPlayerService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->put($this->baseUri.'me/player/seek?position_ms='.$positionMs);
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->put($this->baseUri.'me/player/seek?position_ms='.$positionMs));
 
-        if (! $response->successful()) {
-            $error = $response->json();
+        if (! $response?->successful()) {
+            $error = $response?->json();
             throw new \Exception($error['error']['message'] ?? 'Failed to seek');
         }
     }
@@ -295,10 +296,10 @@ class SpotifyPlayerService
     {
         $this->auth->requireAuth();
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->put($this->baseUri.'me/player/shuffle?state='.($state ? 'true' : 'false'));
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->put($this->baseUri.'me/player/shuffle?state='.($state ? 'true' : 'false')));
 
-        return $response->successful();
+        return $response !== null && $response->successful();
     }
 
     /**
@@ -313,10 +314,10 @@ class SpotifyPlayerService
             throw new \Exception('Invalid repeat state. Use: off, track, or context');
         }
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->put($this->baseUri.'me/player/repeat?state='.$state);
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->put($this->baseUri.'me/player/repeat?state='.$state));
 
-        return $response->successful();
+        return $response !== null && $response->successful();
     }
 
     /**
@@ -329,10 +330,10 @@ class SpotifyPlayerService
         }
 
         // Use /me/player instead of /me/player/currently-playing to get full state including device
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->get($this->baseUri.'me/player');
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->get($this->baseUri.'me/player'));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             $data = $response->json();
             if (isset($data['item'])) {
                 $albumImages = $data['item']['album']['images'] ?? [];
@@ -379,10 +380,10 @@ class SpotifyPlayerService
             return [];
         }
 
-        $response = Http::withToken($this->auth->getAccessToken())
-            ->get($this->baseUri.'artists/'.$artistId);
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
+            ->get($this->baseUri.'artists/'.$artistId));
 
-        if ($response->successful()) {
+        if ($response !== null && $response->successful()) {
             return $response->json('genres') ?? [];
         }
 
@@ -400,12 +401,12 @@ class SpotifyPlayerService
 
         $device = $deviceId ?: $this->getActiveDevice()['id'] ?? null;
 
-        $response = Http::withToken($this->auth->getAccessToken())
+        $response = SpotifyRateLimit::guard(fn () => Http::withToken($this->auth->getAccessToken())
             ->put($this->baseUri.'me/player/play', [
                 'device_id' => $device,
                 'context_uri' => "spotify:playlist:{$playlistId}",
-            ]);
+            ]));
 
-        return $response->successful();
+        return $response !== null && $response->successful();
     }
 }

--- a/app/Support/SpotifyRateLimit.php
+++ b/app/Support/SpotifyRateLimit.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Http\Client\Response;
+
+/**
+ * Circuit breaker for Spotify Web API 429s.
+ *
+ * WHY: the panes (`player:premium`, `watch`, `pulse`, …) poll the Web API all
+ * day. When Spotify rate-limits the app it answers every call with 429 and a
+ * Retry-After that can be HOURS — and every further request just digs the hole
+ * deeper. This breaker persists the resume deadline next to the OAuth token
+ * (rate-limit.json, so every process sees the same state) and short-circuits
+ * all API calls until it passes: callers get the same graceful empties they
+ * already return on failure, WITHOUT touching the network.
+ *
+ * Static on purpose: it is shared process-wide, has no dependencies beyond
+ * config('spotify.token_path'), and the services already construct their HTTP
+ * calls inline — guard() wraps a call site in one line.
+ */
+final class SpotifyRateLimit
+{
+    /** Cool-down (seconds) when a 429 arrives without a Retry-After header. */
+    private const DEFAULT_RETRY_AFTER = 60;
+
+    /**
+     * Run a Spotify Web API call through the breaker: while rate-limited the
+     * request is NOT sent and null is returned (callers treat it like any other
+     * failed response); otherwise the response is inspected so a 429 trips the
+     * breaker for every subsequent call in every process.
+     *
+     * @param  callable(): Response  $request
+     */
+    public static function guard(callable $request): ?Response
+    {
+        if (self::active()) {
+            return null;
+        }
+
+        $response = $request();
+
+        if ($response->status() === 429) {
+            self::hit($response->header('Retry-After'));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Record a 429: persist the resume deadline derived from Retry-After.
+     */
+    public static function hit(?string $retryAfter): void
+    {
+        $seconds = max(1, (int) ($retryAfter ?: self::DEFAULT_RETRY_AFTER));
+
+        $file = self::path();
+        $dir = dirname($file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        file_put_contents($file, json_encode(['resumes_at' => time() + $seconds]));
+    }
+
+    /**
+     * Whether the breaker is currently open (API calls must short-circuit).
+     */
+    public static function active(): bool
+    {
+        return self::resumesAt() !== null;
+    }
+
+    /**
+     * The unix timestamp when Spotify lets us back in, or null when not
+     * rate-limited. An expired deadline is cleaned up on read so the breaker
+     * closes itself without any explicit reset step.
+     */
+    public static function resumesAt(): ?int
+    {
+        $file = self::path();
+
+        if (! is_file($file)) {
+            return null;
+        }
+
+        $data = json_decode((string) file_get_contents($file), true);
+        $deadline = (int) (is_array($data) ? ($data['resumes_at'] ?? 0) : 0);
+
+        if ($deadline <= time()) {
+            @unlink($file);
+
+            return null;
+        }
+
+        return $deadline;
+    }
+
+    /**
+     * Forget the deadline (used by tests; production expiry is automatic).
+     */
+    public static function clear(): void
+    {
+        @unlink(self::path());
+    }
+
+    /**
+     * The deadline lives alongside the OAuth token so every command/daemon
+     * process shares one breaker (and it survives restarts).
+     */
+    private static function path(): string
+    {
+        return dirname((string) config('spotify.token_path')).'/rate-limit.json';
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,20 @@ use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    /**
+     * Point spotify.token_path at a per-process temp dir by default.
+     *
+     * WHY: the SpotifyRateLimit breaker persists its 429 deadline NEXT TO the
+     * token file. With the real default (~/.config/spotify-cli/) a genuine
+     * rate-limit on the developer's machine would short-circuit every faked
+     * HTTP call in the suite — tests must never read (or write) the real
+     * breaker/token state. Tests that care about the path still override it.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['spotify.token_path' => sys_get_temp_dir().'/spotify-cli-test-'.getmypid().'/token.json']);
+    }
 }

--- a/tests/Unit/DaemonCommSniffTest.php
+++ b/tests/Unit/DaemonCommSniffTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Commands\DaemonCommand;
+
+/**
+ * The pure comm-name check behind daemon health detection. The old exact
+ * `$comm === 'spotifyd'` compare was ALWAYS false on macOS — `ps -o comm=`
+ * returns the full binary path, and the preferred binary is spotifyd-rodio —
+ * so health reported the daemon dead forever and --heal never engaged.
+ */
+describe('DaemonCommand::isSpotifydComm', function (): void {
+
+    it('accepts spotifyd binaries', function (string $comm): void {
+        expect(DaemonCommand::isSpotifydComm($comm))->toBeTrue();
+    })->with([
+        'spotifyd',
+        'spotifyd-rodio',
+        '/usr/local/bin/spotifyd',
+        '/Users/jordan/.local/bin/spotifyd-rodio',
+        "  /Users/jordan/.local/bin/spotifyd-rodio\n", // raw ps output, untrimmed
+    ]);
+
+    it('rejects everything else, including recycled PIDs', function (string $comm): void {
+        expect(DaemonCommand::isSpotifydComm($comm))->toBeFalse();
+    })->with([
+        'php',
+        '/bin/bash',
+        '/usr/local/bin/node',
+        '', // process gone — empty ps output
+        '/usr/bin/not-spotifyd-at-all/php', // 'spotifyd' in the path but not the binary
+    ]);
+});

--- a/tests/Unit/Player/RateLimitEmptyStateTest.php
+++ b/tests/Unit/Player/RateLimitEmptyStateTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Player\PlayerRenderer;
+use App\Player\PlayerTheme;
+use App\Player\PlayerViewModel;
+use PhpTui\Tui\Display\Backend\DummyBackend;
+use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Widget\Widget;
+
+/**
+ * The honest rate-limited empty state: while Spotify is 429-ing the app every
+ * poll fails, so "Nothing playing right now" would be a lie — the panel must
+ * say we are rate-limited and when polling resumes. Buffer-rendered like the
+ * other renderer tests (local helper; the PlayerRendererTest helpers are
+ * file-local and load-order dependent, so this file keeps its own).
+ */
+function renderRateLimitPanel(Widget $widget, int $width = 78, int $height = 12): string
+{
+    $backend = new DummyBackend($width, $height);
+    DisplayBuilder::default($backend)->fullscreen()->build()->draw($widget);
+
+    return $backend->toString();
+}
+
+describe('PlayerViewModel rate-limit notice', function (): void {
+
+    it('returns null when not rate-limited', function (): void {
+        $vm = PlayerViewModel::fromPlayback(null);
+
+        expect($vm->rateLimitedUntil)->toBeNull();
+        expect($vm->rateLimitNotice())->toBeNull();
+    });
+
+    it('formats the resume time as ~HH:MM', function (): void {
+        $vm = PlayerViewModel::fromPlayback(null);
+        $vm->rateLimitedUntil = mktime(14, 30, 0, 6, 4, 2026);
+
+        expect($vm->rateLimitNotice())->toBe('⏳ Spotify is rate-limiting us — resumes ~14:30');
+    });
+});
+
+describe('PlayerRenderer rate-limited empty state', function (): void {
+
+    it('renders the default empty state when no notice is given', function (): void {
+        $output = renderRateLimitPanel((new PlayerRenderer(PlayerTheme::forMood('neutral')))->empty());
+
+        expect($output)->toContain('Nothing playing right now');
+        expect($output)->toContain('Press / to search, or start playback on Spotify');
+    });
+
+    it('replaces the misleading empty line with the rate-limit notice', function (): void {
+        $vm = PlayerViewModel::fromPlayback(null);
+        $vm->rateLimitedUntil = mktime(14, 30, 0, 6, 4, 2026);
+
+        $output = renderRateLimitPanel(
+            (new PlayerRenderer(PlayerTheme::forMood('neutral')))->empty($vm->rateLimitNotice())
+        );
+
+        expect($output)->toContain('Spotify is rate-limiting us — resumes ~14:30');
+        expect($output)->not->toContain('Nothing playing right now');
+    });
+});

--- a/tests/Unit/SpotifyRateLimitBreakerTest.php
+++ b/tests/Unit/SpotifyRateLimitBreakerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Services\SpotifyAuthManager;
+use App\Services\SpotifyDiscoveryService;
+use App\Services\SpotifyPlayerService;
+use App\Support\SpotifyRateLimit;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Mockery;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * Service-level proof of the 429 circuit breaker: one rate-limited response
+ * opens the breaker, and every subsequent Spotify Web API call returns its
+ * graceful empty WITHOUT touching the network — the polling panes stop digging
+ * the hole deeper the moment Spotify says back off.
+ */
+beforeEach(function (): void {
+    Config::set('spotify.client_id', 'test_client_id');
+    Config::set('spotify.client_secret', 'test_client_secret');
+
+    $this->configDir = sys_get_temp_dir().'/spotify-breaker-test-'.uniqid();
+    mkdir($this->configDir, 0755, true);
+    Config::set('spotify.token_path', $this->configDir.'/token.json');
+
+    $mockAuth = Mockery::mock(SpotifyAuthManager::class)->makePartial();
+    $mockAuth->shouldReceive('getAccessToken')->andReturn('valid_token');
+    $mockAuth->shouldReceive('requireAuth')->andReturn(null);
+
+    $this->playerService = new SpotifyPlayerService($mockAuth);
+    $this->discoveryService = new SpotifyDiscoveryService($mockAuth);
+});
+
+afterEach(function (): void {
+    SpotifyRateLimit::clear();
+    @rmdir($this->configDir);
+});
+
+describe('Spotify 429 circuit breaker', function (): void {
+
+    it('opens the breaker on a 429 and short-circuits subsequent calls', function (): void {
+        Http::fake([
+            '*/me/player*' => Http::response('', 429, ['Retry-After' => '120']),
+        ]);
+
+        // First poll takes the 429 on the chin — and records the deadline.
+        expect($this->playerService->getCurrentPlayback())->toBeNull();
+        expect(SpotifyRateLimit::active())->toBeTrue();
+        expect(SpotifyRateLimit::resumesAt())->toBeGreaterThan(time() + 100);
+
+        // Every further poll returns its graceful empty WITHOUT a request.
+        expect($this->playerService->getCurrentPlayback())->toBeNull();
+        expect($this->playerService->getDevices())->toBe([]);
+        expect($this->playerService->getQueue())->toBe([]);
+
+        Http::assertSentCount(1);
+    });
+
+    it('short-circuits the discovery service while the breaker is open', function (): void {
+        SpotifyRateLimit::hit('300');
+
+        Http::fake();
+
+        expect($this->discoveryService->search('test'))->toBeNull();
+        expect($this->discoveryService->getTopTracks())->toBe([]);
+        expect($this->discoveryService->getPlaylists())->toBe([]);
+
+        Http::assertNothingSent();
+    });
+
+    it('degrades control toggles to false instead of hitting the network', function (): void {
+        SpotifyRateLimit::hit('300');
+
+        Http::fake();
+
+        expect($this->playerService->setVolume(50))->toBeFalse();
+        expect($this->playerService->setShuffle(true))->toBeFalse();
+
+        Http::assertNothingSent();
+    });
+
+    it('resumes real requests once the deadline expires', function (): void {
+        file_put_contents($this->configDir.'/rate-limit.json', json_encode(['resumes_at' => time() - 1]));
+
+        Http::fake([
+            '*/me/player/devices*' => Http::response(['devices' => [['id' => 'd1', 'name' => 'Mac']]]),
+        ]);
+
+        expect($this->playerService->getDevices())->toHaveCount(1);
+        expect(SpotifyRateLimit::active())->toBeFalse();
+
+        Http::assertSentCount(1);
+    });
+});

--- a/tests/Unit/Support/SpotifyRateLimitTest.php
+++ b/tests/Unit/Support/SpotifyRateLimitTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Support\SpotifyRateLimit;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function (): void {
+    // The breaker persists next to the token file — point it at a fresh temp dir.
+    $this->configDir = sys_get_temp_dir().'/spotify-rate-limit-test-'.uniqid();
+    mkdir($this->configDir, 0755, true);
+    Config::set('spotify.token_path', $this->configDir.'/token.json');
+});
+
+afterEach(function (): void {
+    SpotifyRateLimit::clear();
+    @rmdir($this->configDir);
+});
+
+describe('SpotifyRateLimit', function (): void {
+
+    it('is inactive when no deadline has been persisted', function (): void {
+        expect(SpotifyRateLimit::active())->toBeFalse();
+        expect(SpotifyRateLimit::resumesAt())->toBeNull();
+    });
+
+    it('persists the Retry-After deadline on hit and reports active', function (): void {
+        SpotifyRateLimit::hit('120');
+
+        expect(SpotifyRateLimit::active())->toBeTrue();
+        expect(SpotifyRateLimit::resumesAt())
+            ->toBeGreaterThanOrEqual(time() + 118)
+            ->toBeLessThanOrEqual(time() + 122);
+        expect(file_exists($this->configDir.'/rate-limit.json'))->toBeTrue();
+    });
+
+    it('falls back to a default cool-down when Retry-After is missing', function (): void {
+        SpotifyRateLimit::hit(null);
+
+        expect(SpotifyRateLimit::resumesAt())
+            ->toBeGreaterThanOrEqual(time() + 58)
+            ->toBeLessThanOrEqual(time() + 62);
+    });
+
+    it('expires automatically once the deadline passes and removes the file', function (): void {
+        file_put_contents($this->configDir.'/rate-limit.json', json_encode(['resumes_at' => time() - 5]));
+
+        expect(SpotifyRateLimit::active())->toBeFalse();
+        expect(SpotifyRateLimit::resumesAt())->toBeNull();
+        expect(file_exists($this->configDir.'/rate-limit.json'))->toBeFalse();
+    });
+
+    it('survives garbage in the file without throwing', function (): void {
+        file_put_contents($this->configDir.'/rate-limit.json', 'not json');
+
+        expect(SpotifyRateLimit::active())->toBeFalse();
+    });
+
+    it('clears the persisted deadline', function (): void {
+        SpotifyRateLimit::hit('300');
+        SpotifyRateLimit::clear();
+
+        expect(SpotifyRateLimit::active())->toBeFalse();
+    });
+
+    describe('guard()', function (): void {
+
+        it('short-circuits without invoking the request while active', function (): void {
+            SpotifyRateLimit::hit('300');
+            $invoked = false;
+
+            $result = SpotifyRateLimit::guard(function () use (&$invoked): Response {
+                $invoked = true;
+
+                return new Response(new Psr7Response(200));
+            });
+
+            expect($result)->toBeNull();
+            expect($invoked)->toBeFalse();
+        });
+
+        it('passes successful responses through and stays closed', function (): void {
+            $result = SpotifyRateLimit::guard(fn (): Response => new Response(new Psr7Response(200, [], '{}')));
+
+            expect($result)->not->toBeNull();
+            expect($result->successful())->toBeTrue();
+            expect(SpotifyRateLimit::active())->toBeFalse();
+        });
+
+        it('trips the breaker when the response is a 429', function (): void {
+            $result = SpotifyRateLimit::guard(
+                fn (): Response => new Response(new Psr7Response(429, ['Retry-After' => '120']))
+            );
+
+            expect($result->status())->toBe(429);
+            expect(SpotifyRateLimit::active())->toBeTrue();
+            expect(SpotifyRateLimit::resumesAt())->toBeGreaterThan(time() + 100);
+        });
+    });
+});


### PR DESCRIPTION
## Why

Spotify has rate-limited this app (HTTP 429, `Retry-After` ≈ 14h) because our panes poll the Web API every few seconds, all day. While throttled, **every call fails and digs the hole deeper**, and the premium player misleadingly shows "Nothing playing right now". Separately, `spotify daemon health` always reports **dead** because of a broken process check, so its `--heal` loop never engages.

## Fix 1 — 429 circuit breaker

- **`App\Support\SpotifyRateLimit`** — when any Web API response is 429, the `Retry-After` deadline is persisted next to the OAuth token (`~/.config/spotify-cli/rate-limit.json`, so every process/pane shares one breaker and it survives restarts). Until that deadline, `SpotifyRateLimit::guard()` short-circuits the call **without touching the network**, and the breaker self-expires on read.
- Wired into **every** `api.spotify.com` call site in `SpotifyPlayerService` + `SpotifyDiscoveryService` (the oEmbed fallback hits `open.spotify.com`, not the rate-limited Web API, so it stays live). Callers return the same graceful empties they already used on failure (`null` / `[]` / `false`), so `watch`, `pulse`, and both players get the behavior for free.
- **Honest empty state**: `SpotifyRateLimit::resumesAt(): ?int` feeds the premium player, which now renders `⏳ Spotify is rate-limiting us — resumes ~HH:MM` instead of the misleading "Nothing playing right now" (label lives on `PlayerViewModel` so the wording/HH:MM formatting is unit-tested; php-tui's centred alignment keeps the box aligned).
- **Polling intervals**: checked per the plan — `watch` already defaults to **10s (min 3)** and `pulse` to 15s, so no bump was needed; the 5s default this was written against no longer exists. The real day-long pressure relief is the breaker itself: the first 429 stops all traffic until the deadline passes.
- Test isolation: `Tests\TestCase` now points `spotify.token_path` at a temp dir by default, so a *real* rate-limit on a dev machine can never short-circuit the suite's faked HTTP calls.
- Known out-of-scope path: `ServeCommand` embeds a standalone curl-based server script that also hits the Web API; it doesn't go through the services, so it's not covered by the breaker (worth a follow-up).

## Fix 2 — daemon health detection

- `isDaemonRunning()` / `getDaemonPid()` / orphan adoption compared `ps -p PID -o comm=` to the literal `'spotifyd'` — **always false**, because (a) macOS `comm` returns the *full path* and (b) the binary is `spotifyd-rodio`. Extracted a pure, unit-tested `DaemonCommand::isSpotifydComm()` that compares `str_starts_with(basename($comm), 'spotifyd')`.
- Health log scanning loaded the **entire** `spotifyd.log` (1.5M lines, 14 weeks of history) into memory via `file()` — once for the error scan, again for the line count. Now `tail -n 500` for the error window (only *recent* errors say anything about health *now*) and `wc -l` for the count.

## Tests

- `SpotifyRateLimitTest` — persist / default cool-down / expiry+cleanup / garbage tolerance / `guard()` short-circuit + trip
- `SpotifyRateLimitBreakerTest` — a faked 429 (`Retry-After: 120`) opens the breaker and subsequent service calls **send zero requests** (`Http::assertSentCount(1)` / `assertNothingSent`); calls resume after expiry
- `RateLimitEmptyStateTest` — VM notice formatting + buffer-rendered empty-state swap
- `DaemonCommSniffTest` — `spotifyd`, `spotifyd-rodio`, `/full/path/spotifyd-rodio` pass; `php`, `/bin/bash`, recycled-PID empties fail

`composer test`: **716 passed (2126 assertions)** · PHPStan clean · Pint clean. (Not verified against the live API — we're rate-limited right now; that's the point. `Http::fake` covers the contract.)

🎵 Now playing: Rick Astley - Never Gonna Give You Up
🔗 Track: https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC