### PR TITLE
chore: vector ^0.2.1 from Packagist + hide AI scaffolding commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "laravel/mcp": "^0.5.9",
         "laravel/prompts": "^0.3",
         "php-tui/php-tui": "^0.2.1",
-        "the-shit/vector": "dev-main"
+        "the-shit/vector": "^0.2.1"
     },
     "require-dev": {
         "laravel/pint": "^1.22",
@@ -92,12 +92,5 @@
     "prefer-stable": true,
     "bin": [
         "spotify"
-    ],
-    "repositories": [
-        {
-            "name": "vector",
-            "type": "vcs",
-            "url": "https://github.com/the-shit/vector.git"
-        }
     ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f33efd8fa2d035992373a5c25dab219",
+    "content-hash": "365603813d29f35b6c6bfff7dcbea9b8",
     "packages": [
         {
             "name": "brick/math",
@@ -714,16 +714,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.11.0",
+            "version": "7.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b"
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c987f8ce84b8434fa430795eca0f3430663da72b",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "shasum": ""
             },
             "require": {
@@ -742,7 +742,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.4",
+                "guzzlehttp/test-server": "^0.5",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -822,7 +822,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.11.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
             },
             "funding": [
                 {
@@ -838,7 +838,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:40:51+00:00"
+            "time": "2026-06-07T22:54:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -4125,16 +4125,16 @@
         },
         {
             "name": "saloonphp/saloon",
-            "version": "v3.15.0",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/saloonphp/saloon.git",
-                "reference": "8039c76132ca52d08c887407773a770c15ab04a0"
+                "reference": "1307b1d72cacdd2c9c20978cdf7a0b720b4bf3bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/saloonphp/saloon/zipball/8039c76132ca52d08c887407773a770c15ab04a0",
-                "reference": "8039c76132ca52d08c887407773a770c15ab04a0",
+                "url": "https://api.github.com/repos/saloonphp/saloon/zipball/1307b1d72cacdd2c9c20978cdf7a0b720b4bf3bb",
+                "reference": "1307b1d72cacdd2c9c20978cdf7a0b720b4bf3bb",
                 "shasum": ""
             },
             "require": {
@@ -4194,7 +4194,7 @@
             ],
             "support": {
                 "issues": "https://github.com/saloonphp/saloon/issues",
-                "source": "https://github.com/saloonphp/saloon/tree/v3.15.0"
+                "source": "https://github.com/saloonphp/saloon/tree/v4.0.0"
             },
             "funding": [
                 {
@@ -4202,7 +4202,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-02T22:04:13+00:00"
+            "time": "2026-03-17T22:58:33+00:00"
         },
         {
             "name": "symfony/clock",
@@ -6706,33 +6706,33 @@
         },
         {
             "name": "the-shit/vector",
-            "version": "dev-main",
+            "version": "v0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/the-shit/vector.git",
-                "reference": "352137fdf633f4cef16431e741a6771f3b5557ba"
+                "reference": "2be8a18c94254cc574db92e0ca39423fe59c4761"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/the-shit/vector/zipball/352137fdf633f4cef16431e741a6771f3b5557ba",
-                "reference": "352137fdf633f4cef16431e741a6771f3b5557ba",
+                "url": "https://api.github.com/repos/the-shit/vector/zipball/2be8a18c94254cc574db92e0ca39423fe59c4761",
+                "reference": "2be8a18c94254cc574db92e0ca39423fe59c4761",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.3",
-                "saloonphp/saloon": "^3.0"
+                "saloonphp/saloon": "^4.0"
             },
             "require-dev": {
                 "laravel/framework": "^11.0|^12.0",
+                "laravel/pao": "^1.1",
                 "laravel/pint": "^1.0",
-                "nunomaduro/pao": "dev-main",
+                "opis/json-schema": "^2.6",
                 "orchestra/testbench": "^9.0|^10.0",
                 "pestphp/pest": "^4.0",
                 "pestphp/pest-plugin-arch": "^4.0",
                 "rector/rector": "^2.0",
                 "spatie/invade": "^2.1"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -6746,11 +6746,7 @@
                     "TheShit\\Vector\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "TheShit\\Vector\\Tests\\": "tests/"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -6770,10 +6766,10 @@
                 "vector"
             ],
             "support": {
-                "source": "https://github.com/the-shit/vector/tree/main",
-                "issues": "https://github.com/the-shit/vector/issues"
+                "issues": "https://github.com/the-shit/vector/issues",
+                "source": "https://github.com/the-shit/vector/tree/v0.2.1"
             },
-            "time": "2026-04-04T20:10:11+00:00"
+            "time": "2026-06-12T02:45:18+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -10094,9 +10090,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "the-shit/vector": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/config/commands.php
+++ b/config/commands.php
@@ -83,6 +83,8 @@ return [
         Laravel\Mcp\Console\Commands\MakePromptCommand::class,
         Laravel\Mcp\Console\Commands\MakeResourceCommand::class,
         Laravel\Mcp\Console\Commands\InspectorCommand::class,
+        Laravel\Ai\Console\Commands\MakeAgentCommand::class,
+        Laravel\Ai\Console\Commands\MakeToolCommand::class,
         ...$devHidden,
     ],
 


### PR DESCRIPTION
## What

- Require `the-shit/vector ^0.2.1` (just released) instead of `dev-main`, and drop the VCS repository block. The `dev-main` requirement broke `composer global require the-shit/music` for consumers: root stability defaults to stable and `repositories` entries don't propagate. Pulls in Saloon v4 transitively (no direct Saloon usage in this app; `QdrantEventSink` is the only vector consumer and is unaffected).
- Hide `make:agent` / `make:tool` (laravel/ai scaffolding) from the command list, matching the existing treatment of the laravel/mcp make commands. They remain runnable if typed explicitly.

## Verification

- 716 tests passing (2126 assertions)
- Pint clean, PHPStan no errors
- `spotify list` no longer shows make commands (44 → 42)