### PR TITLE
fix: disable composer process timeout for test scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,14 @@
         }
     },
     "scripts": {
-        "test": "@php -d disable_functions=pcntl_fork vendor/bin/pest",
-        "test:coverage": "@php -d disable_functions=pcntl_fork vendor/bin/pest --coverage",
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php -d disable_functions=pcntl_fork vendor/bin/pest"
+        ],
+        "test:coverage": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php -d disable_functions=pcntl_fork vendor/bin/pest --coverage"
+        ],
         "lint": "pint --dirty",
         "lint:check": "pint --test",
         "analyse": "phpstan analyse --no-progress",


### PR DESCRIPTION
The Solo 🧪 Tests process has been showing Failed for over a day with every individual test passing. Root cause: composer's default 300-second process timeout kills the pest run mid-suite when it runs slow (Xdebug active in that terminal pushes the ~30s suite past 5 minutes).

Fix is the official escape hatch — `Composer\Config::disableProcessTimeout` on the `test` and `test:coverage` scripts, so the suite always runs to completion and pass/fail reflects the tests, not the clock.

Verified: `composer validate` clean, `composer test` → 716 passed.