### PR TITLE
fix: stop the test suite hanging when run in a real terminal

### DIFF
--- a/tests/Feature/PlayerCommandTest.php
+++ b/tests/Feature/PlayerCommandTest.php
@@ -37,7 +37,9 @@ describe('PlayerCommand', function (): void {
 
         $this->artisan('player')
             ->expectsOutputToContain('🎵 Spotify Interactive Player')
-            ->expectsOutputToContain('Loading...');
+            ->expectsOutputToContain('Loading...')
+            ->expectsQuestion('What would you like to do?', 'exit')
+            ->expectsOutputToContain('👋 Goodbye!');
     });
 
     it('displays current track info', function (): void {
@@ -62,7 +64,9 @@ describe('PlayerCommand', function (): void {
 
         $this->artisan('player')
             ->expectsOutputToContain('🎵 Spotify Interactive Player')
-            ->expectsOutputToContain('Loading...');
+            ->expectsOutputToContain('Loading...')
+            ->expectsQuestion('Controls', 'exit')
+            ->expectsOutputToContain('👋 Goodbye!');
     });
 
 });

--- a/tests/Feature/SetupCommandTest.php
+++ b/tests/Feature/SetupCommandTest.php
@@ -66,10 +66,11 @@ describe('SetupCommand', function (): void {
                 'client_secret' => 'existingclientsecret12345',
             ]));
 
-            // With reset flag, it should proceed to setup
-            Prompt::interactive(false);
-
+            // Declining the confirmation cancels the reset cleanly — the same
+            // path the old non-interactive default-false behaviour exercised.
             $this->artisan('setup', ['--reset' => true])
+                ->expectsConfirmation('This will remove your stored Spotify credentials. Continue?', 'no')
+                ->expectsOutputToContain('Setup cancelled.')
                 ->assertExitCode(0);
         });
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -92,6 +92,24 @@ uses()->afterEach(function (): void {
 
 /*
 |--------------------------------------------------------------------------
+| Laravel Prompts — fall back to Symfony questions in every test
+|--------------------------------------------------------------------------
+|
+| Without the fallback, select()/text() render to the real terminal: under
+| a TTY they block on keyboard input forever (the suite used to hang
+| deterministically at PlayerCommandTest when run in a real terminal), and
+| without one they only terminate by throwing on EOF. With the fallback,
+| prompts route through Symfony questions, expectsQuestion() can drive
+| them, and the suite behaves identically in CI, pipes, and terminals.
+| fallbackWhen() ORs into sticky static state, so set it suite-wide here
+| rather than per-file where it would be order-dependent.
+*/
+uses()->beforeEach(function (): void {
+    \Laravel\Prompts\Prompt::fallbackWhen(true);
+})->in('Feature', 'Unit');
+
+/*
+|--------------------------------------------------------------------------
 | Laravel Prompts spin() — deterministic full suite (no SIGHUP hang)
 |--------------------------------------------------------------------------
 |


### PR DESCRIPTION
Root cause of the Solo 🧪 Tests process never finishing (and the reason the old composer 300s timeout kept 'failing' it — see #151).

## The bug

`PlayerCommandTest`'s loop tests pass the interactivity guard and enter the player's `while` loop. They only terminated because Laravel Prompts' `select()` throws on EOF when stdin is **not** a TTY (CI, pipes, sandboxes). Run the same suite in a real terminal and `select()` renders and blocks on keyboard input forever — the suite hangs deterministically right after `PlayCommandTest`, every time. Reproduced and verified with `script(1)`.

## The fix

- **`tests/Pest.php`**: route Prompts through the Symfony question fallback suite-wide (`Prompt::fallbackWhen(true)` in a `beforeEach`). `fallbackWhen()` ORs into sticky static state, so setting it per-file would make other files' behavior depend on test order — suite-wide is the only deterministic placement.
- **`PlayerCommandTest`**: the two loop tests now drive the prompt explicitly (`expectsQuestion(..., 'exit')`) and assert the goodbye path, instead of relying on EOF-throw side effects.
- **`SetupCommandTest`**: the `--reset` test now stubs its confirmation (`expectsConfirmation(..., 'no')`) — it previously leaned on the non-interactive default.

## Verification

- Full suite piped: 716 passed (2132 assertions)
- Full suite under a pseudo-TTY via `script(1)`: **716 passed, exit 0** — previously hung indefinitely
- Pint, PHPStan, Rector all clean